### PR TITLE
added default fields to base class, add channels, traces methods

### DIFF
--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -264,7 +264,7 @@ class NumpySegmentationExtractor(SegmentationExtractor):
     def get_sampling_frequency(self):
         return self.samp_freq
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -172,7 +172,7 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
     def get_sampling_frequency(self):
         return self.samp_freq
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -157,7 +157,7 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
     def get_sampling_frequency(self):
         return self.samp_freq
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -258,7 +258,7 @@ class SimaSegmentationExtractor(SegmentationExtractor):
     def get_sampling_frequency(self):
         return self.samp_freq
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None):
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -209,7 +209,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         pass
 
     @abstractmethod
-    def get_traces(self) -> ArrayType:
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None) -> ArrayType:
         """
         Return RoiResponseSeries
         Returns

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -16,7 +16,10 @@ class SegmentationExtractor(ABC, BaseExtractor):
 
     def __init__(self):
         BaseExtractor.__init__(self)
-        self._sampling_frequency = None
+        self._sampling_frequency = np.float('NaN')
+        self._channel_names = ['OpticalChannel']
+        self._raw_movie_file_location = ''
+        self.no_planes = 1
 
     @property
     def image_size(self):
@@ -64,7 +67,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         Returns
         -------
         roi_locs: np.array
-            Array with the first column representing the x (width) and second representing
+            Array with the first row representing the x (width) and second representing
             the y (height) coordinates of the ROI.
         """
         return self.get_roi_locations()
@@ -205,6 +208,28 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         pass
 
+    @abstractmethod
+    def get_traces(self) -> ArrayType:
+        """
+        Return RoiResponseSeries
+        Returns
+        -------
+        traces: array_like
+            2-D array (ROI x timepoints)
+        """
+        pass
+
+    def get_traces_dict(self):
+        """
+        Returns traces as a dictionary with key as the name of the ROiResponseSeries
+        Returns
+        -------
+        _roi_response_dict: dict
+            dictionary with key, values representing different types of RoiResponseSeries
+            Flourescence, Neuropil, Deconvolved, Background etc
+        """
+        return self._roi_response_dict
+
     def get_sampling_frequency(self):
         """This function returns the sampling frequency in units of Hz.
 
@@ -225,6 +250,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         return len(self.get_roi_ids())
 
+    @abstractmethod
     def get_images(self):
         """
         Retrieve any relevant greyscale images from the pipeline
@@ -238,7 +264,35 @@ class SegmentationExtractor(ABC, BaseExtractor):
                 -<image_name2>: <image_data2>
                 -<image_name3>: <image_data3>
         """
-        raise NotImplementedError
+        pass
+
+    def get_channel_names(self):
+        """
+        Names of channels in the pipeline
+        Returns
+        -------
+        _channel_names: list
+            names of channels (str)
+        """
+        return self._channel_names
+
+    def get_num_channels(self):
+        """
+        Number of channels in the pipeline
+        Returns
+        -------
+        no_of_channels: int
+        """
+        return len(self._channel_names)
+
+    def get_movie_location(self):
+        """
+        Local disc location of the raw movie
+        Returns
+        -------
+        _raw_movie_file_location: str
+        """
+        return self._raw_movie_file_location
 
     @staticmethod
     def write_segmentation(segmentation_extractor, savepath):


### PR DESCRIPTION
`self._sampling_frequency`: already present from ImagingExtractors, but changed the default value from None to NaN since RoiResponseSeries would require this in the absence of timestamps. Keeping None, it complains. 
s`elf._channel_names` = ['Optical_channel'], this is the default name I have chosen for channels for which there are no names. We can debate about this. Its a list of len 1 reflecting the default number of assumed channels. 
`self._raw_movie_file_location:` required by method: get_movie_location() and some classes dont have this info but all need it. Makes sense to define it in the base then. 
`self.no_planes`: default is 1 for all the classes, would be different for the MultiSortingExtractor that we develop later. this is currently required by nwbwriter, so I though of defining this explicitly. 
`get_traces_dict() `return a dictionary with all the found ROIResponseSEries for the pipeline, for example suite2p has 3: Flourescence, Neuropil and deconvolved. Its different from `get_traces()` which currently returns a specific trace