### PR TITLE
Dict as attributes

### DIFF
--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -2,7 +2,8 @@ import numpy as np
 from pathlib import Path
 from ...segmentationextractor import SegmentationExtractor
 from ...imagingextractor import ImagingExtractor
-from ...extraction_tools import get_video_shape, _pixel_mask_extractor
+from ...extraction_tools import get_video_shape
+
 
 # TODO this class should also be able to instantiate an in-memory object (useful for testing)
 class NumpyImagingExtractor(ImagingExtractor):
@@ -93,11 +94,10 @@ class NumpySegmentationExtractor(SegmentationExtractor):
     all data must be entered manually as arguments.
     """
 
-    def __init__(self, filepath=None, image_masks=None,
-                 pixel_masks=None, signal=None,
+    def __init__(self, image_masks, signal,
                  rawfileloc=None, accepted_lst=None,
-                 summary_image=None, roi_idx=None,
-                 roi_locs=None, samp_freq=None,
+                 mean_image=None, correlation_image=None,
+                 roi_idx=None, roi_locs=None, samp_freq=None,
                  rejected_list=None, channel_names=None,
                  movie_dims=None):
         """
@@ -105,17 +105,17 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         ----------
         filepath: str
             The location of the folder containing the custom file format.
-        image_masks: np.ndarray (dimensions: image width x height x # of ROIs)
+        image_masks: np.ndarray
             Binary image for each of the regions of interest
-        pixel_masks: list
-            list of np.ndarray (dimensions: no_pixels X 2) pixel mask for every ROI
-        signal: np.ndarray (dimensions: # of ROIs x # timesteps)
+        signal: np.ndarray
             Fluorescence response of each of the ROI in time
-        summary_image: np.ndarray (dimensions: d1 x d2)
-            Mean or the correlation image
-        roi_idx: int list (length is # of ROIs)
+        mean_image: np.ndarray
+            Mean image
+        correlation_image: np.ndarray
+            correlation image
+        roi_idx: int list
             Unique ids of the ROIs if any
-        roi_locs: np.ndarray (dimensions: # of ROIs x 2)
+        roi_locs: np.ndarray
             x and y location representative of ROI mask
         samp_freq: float
             Frame rate of the movie
@@ -123,22 +123,16 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             list of ROI ids that are rejected manually or via automated rejection
         channel_names: list
             list of strings representing channel names
-        movie_dims: list(2-D)
+        movie_dims: list
             height x width of the movie
         """
         SegmentationExtractor.__init__(self)
-        self.filepath = filepath
-        if image_masks is None:
-            self.image_masks = np.empty([0, 0, 0])
-        if pixel_masks is None:
-            self.pixel_masks = pixel_masks
-        if signal is None:#initialize with a empty value
-            self._roi_response = np.empty([0, 0])
-        else:
-            self._roi_response = signal
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-        self._movie_dims = movie_dims
-        self._summary_image = summary_image
+        self.image_masks = image_masks
+        self._roi_response = signal
+        self._roi_response_fluorescence = self._roi_response
+        self._movie_dims = movie_dims if movie_dims is not None else image_masks.shape
+        self._images_mean = mean_image
+        self._images_correlation = correlation_image
         self._raw_movie_file_location = rawfileloc
         self._roi_ids = roi_idx
         self._roi_locs = roi_locs

--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -196,19 +196,6 @@ class NumpySegmentationExtractor(SegmentationExtractor):
     def get_num_frames(self):
         return self._roi_response.shape[1]
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = list(range(self.get_num_rois()))
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        return self._roi_response[roi_idx_, start_frame:end_frame]
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
@@ -217,22 +204,6 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return self.image_masks[:, :, roi_idx_]
-
-    def get_roi_pixel_masks(self, roi_ids=None):
-        if roi_ids is None:
-            roi_idx_ = self.roi_ids
-        else:
-            roi_idx = [np.where(i == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        temp = np.empty((1, 4))
-        for i, roiid in enumerate(roi_idx_):
-            temp = \
-                np.append(temp, self.pixel_masks[self.pixel_masks[:, 3] == roiid, :], axis=0)
-        return temp[1::, :]
-
-    def get_images(self):
-        return {'Images': {'meanImg': self._summary_image}}
 
     def get_image_size(self):
         return self._movie_dims

--- a/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -295,22 +295,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
         else:
             return self._roi_locs.data[:].T
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name=None):
-        if name is None:
-            name = self._roi_names[0]
-            print(f'returning traces for {name}')
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        return np.array([self._roi_response_dict[name][int(i), start_frame:end_frame] for i in roi_idx_])
-
     def get_num_frames(self):
         return self._roi_response.shape[1]
 
@@ -329,21 +313,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
     def get_num_rois(self):
         return self.roi_ids.size
 
-    def get_roi_pixel_masks(self, roi_ids=None):
-        if self.pixel_masks is None:
-            return None
-        if roi_ids is None:
-            roi_idx_ = self.roi_ids
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        temp = np.empty((1, 4))
-        for i, roiid in enumerate(roi_idx_):
-            temp = \
-                np.append(temp, self.pixel_masks[self.pixel_masks[:, 3] == roiid, :], axis=0)
-        return temp[1::, :]
-
     def get_roi_image_masks(self, roi_ids=None):
         if self.image_masks is None:
             return None
@@ -354,15 +323,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return np.array([self.image_masks[:, :, int(i)].T for i in roi_idx_]).T
-
-    def get_images(self):
-        imag_dict = {i.name: np.array(i.data) for i in self.nwbfile.all_children() if i.name in self._greyscaleimages}
-        _ = {i.name: i for i in self.nwbfile.all_children() if i.name in self._greyscaleimages}
-        if imag_dict:
-            parent_name = _[self._greyscaleimages[0]].parent.name
-            return {parent_name: imag_dict}
-        else:
-            return None
 
     def get_image_size(self):
         return self._extimage_dims

--- a/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -97,19 +97,6 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
     def get_num_frames(self):
         return self._roi_response.shape[1]
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        return np.array([self._roi_response[int(i), start_frame:end_frame] for i in roi_idx_])
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
@@ -118,22 +105,6 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return np.array([self.image_masks[:, :, int(i)].T for i in roi_idx_]).T
-
-    def get_roi_pixel_masks(self, roi_ids=None):
-        if roi_ids is None:
-            roi_idx_ = self.roi_ids
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        temp = np.empty((1, 4))
-        for i, roiid in enumerate(roi_idx_):
-            temp = \
-                np.append(temp, self.pixel_masks[self.pixel_masks[:, 3] == roiid, :], axis=0)
-        return temp[1::, :]
-
-    def get_images(self):
-        return {'Images': {'meanImg': self._summary_image_read()}}
 
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -28,15 +28,12 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
         self._dataset_file, self._group0 = self._file_extractor_read()
         self.image_masks = self._image_mask_extractor_read()
         self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-        self.pixel_masks = _pixel_mask_extractor(self.image_masks, self.roi_ids)
-        self._total_time = self._tot_exptime_extractor_read()
+        self._roi_response_fluorescence = self._roi_response
         self._raw_movie_file_location = self._raw_datafile_read()
-        self._sampling_frequency = self._roi_response.shape[1]/self._total_time
-        # file close:
-        # self._file_close()
+        self._sampling_frequency = self._roi_response.shape[1]/self._tot_exptime_extractor_read()
+        self._images_correlation = self._summary_image_read()
 
-    def _file_close(self):
+    def __del__(self):
         self._dataset_file.close()
 
     def _file_extractor_read(self):

--- a/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -99,20 +99,6 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
     def get_num_frames(self):
         return self._roi_response.shape[1]
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        roi_response = self._trace_extractor_read()
-        return np.array([roi_response[int(i), start_frame:end_frame] for i in roi_idx_])
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = self.roi_ids
@@ -122,21 +108,5 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return np.array([self.image_masks[:, :, int(i)].T for i in roi_idx_]).T
 
-    def get_roi_pixel_masks(self, roi_ids=None):
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        temp = np.empty((1, 4))
-        for i, roiid in enumerate(roi_idx_):
-            temp = \
-                np.append(temp, self.pixel_masks[self.pixel_masks[:, 3] == roiid, :], axis=0)
-        return temp[1::, :]
-
-    def get_images(self):
-        return {'Images': {'meanImg': self._summary_image_read()}}
-    
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -28,15 +28,12 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
         self._dataset_file, self._group0 = self._file_extractor_read()
         self.image_masks = self._image_mask_extractor_read()
         self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-        self.pixel_masks = _pixel_mask_extractor(self.image_masks, self.get_roi_ids())
-        self._total_time = self._tot_exptime_extractor_read()
+        self._roi_response_fluorescence = self._roi_response
         self._raw_movie_file_location = self._raw_datafile_read()
-        self._sampling_frequency = self._roi_response.shape[1]/self._total_time
-        # file close:
-        # self._file_close()
+        self._sampling_frequency = self._roi_response.shape[1]/self._tot_exptime_extractor_read()
+        self._images_correlation = self._summary_image_read()
 
-    def _file_close(self):
+    def __del__(self):
         self._dataset_file.close()
 
     def _file_extractor_read(self):

--- a/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -47,8 +47,8 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         self.image_masks = self._image_mask_extractor_read()
         self.pixel_masks = _pixel_mask_extractor(self.image_masks, self.roi_ids)
         self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-
+        self._roi_response_fluorescence = self._roi_response
+        self._images_mean = self._summary_image_read()
 
     @staticmethod
     def _convert_sima(old_pkl_loc):

--- a/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -180,19 +180,6 @@ class SimaSegmentationExtractor(SegmentationExtractor):
     def get_num_frames(self):
         return self._roi_response.shape[1]
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        return self._roi_response[roi_idx_, start_frame:end_frame]
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
@@ -202,24 +189,8 @@ class SimaSegmentationExtractor(SegmentationExtractor):
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return self.image_masks[:, :, roi_idx_]
 
-    def get_roi_pixel_masks(self, roi_ids=None):
-        if roi_ids is None:
-            roi_idx_ = self.roi_ids
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        temp = np.empty((1, 4))
-        for i, roiid in enumerate(roi_idx_):
-            temp = \
-                np.append(temp, self.pixel_masks[self.pixel_masks[:, 3] == roiid, :], axis=0)
-        return temp[1::, :]
-
-    def get_images(self):
-        out = {'Images': dict()}
-        for j,i in enumerate(self._channel_names):
-            out['Images'].update({f'meanImg_{i}': self._summary_image_read()[:,:,j]})
-        return out
+    def get_images(self, name='mean'):
+        return super(SimaSegmentationExtractor, self).get_images(name=name)
 
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -90,26 +90,6 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
     def get_num_frames(self):
         return self.ops['nframes']
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name='Fluorescence'):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames() + 1
-        if roi_ids is None:
-            roi_idx_ = range(self.get_num_rois())
-        else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
-            ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
-            roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        if name == 'Fluorescence':
-            return self.F[[roi_idx_], start_frame:end_frame]
-        if name == 'Neuropil':
-            return self.Fneu[[roi_idx_], start_frame:end_frame]
-        if name == 'Deconvolved':
-            return self.spks[[roi_idx_], start_frame:end_frame]
-        else:
-            return None
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
@@ -132,20 +112,6 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return [pixel_mask[i] for i in roi_idx_]
-
-    def get_images(self):
-        bg_strs = ['meanImg', 'Vcorr', 'max_proj', 'meanImg_chan2']
-        out_dict = {'Images': {}}
-        for bstr in bg_strs:
-            if bstr in self.ops:
-                if bstr == 'Vcorr' or bstr == 'max_proj':
-                    img = np.zeros((self.ops['Ly'], self.ops['Lx']), np.float32)
-                    img[self.ops['yrange'][0]:self.ops['yrange'][-1],
-                    self.ops['xrange'][0]:self.ops['xrange'][-1]] = self.ops[bstr]
-                else:
-                    img = self.ops[bstr]
-                out_dict['Images'].update({bstr: img})
-        return out_dict
 
     def get_image_size(self):
         return [self.ops['Lx'], self.ops['Ly']]

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from spikeextractors.baseextractor import BaseExtractor
 import numpy as np
 from .extraction_tools import ArrayType
-
+from .extraction_tools import _pixel_mask_extractor
 
 class SegmentationExtractor(ABC, BaseExtractor):
     """
@@ -16,7 +16,15 @@ class SegmentationExtractor(ABC, BaseExtractor):
 
     def __init__(self):
         BaseExtractor.__init__(self)
-        self._sampling_frequency = None
+        self._sampling_frequency = np.float('NaN')
+        self._channel_names = ['OpticalChannel']
+        self._raw_movie_file_location = ''
+        self.no_planes = 1
+        self._roi_response_fluorescence = None
+        self._roi_response_neuropil = None
+        self._roi_response_deconvolved = None
+        self._images_correlation = None
+        self._images_mean = None
 
     @property
     def image_size(self):
@@ -64,8 +72,8 @@ class SegmentationExtractor(ABC, BaseExtractor):
         Returns
         -------
         roi_locs: np.array
-            Array with the first column representing the x (width) and second representing
-            the y (height) coordinates of the ROI.
+            Array with the first row representing the y (height) and second representing
+            the x (width) coordinates of the ROI.
         """
         return self.get_roi_locations()
 


### PR DESCRIPTION
This PR converts the previous dictionaries to separate attributes: (There are 2 commits)
f2a273740456d70f2e9cd689476720172b5db4df comments: 
1. `self._roi_response_series_dict` > `self._roi_response_flourescence` ,` self._roi_response_neuropil`, `self._roi_response_deconvolved `
Though there is a get method to return these attributes as a dictionary (in the base class)
2. Images are stored in `self._images_mean`, `self_images_correlation` , once again there is a method get_images_dict() that returns these images as a dictionary like before. 
I think with such an implementation we can now have standard naming for such attributes

d91d4178a81cb306d218b13daa6e88be4dd05d27 comments:
With this standarsization, all classes now share a common method `get_traces(),` `get_images()`, `get_pixel_masks()`-not stored by default
