### PR TITLE
PR2: attributes rename

### DIFF
--- a/roiextractors/extraction_tools.py
+++ b/roiextractors/extraction_tools.py
@@ -43,8 +43,8 @@ def _image_mask_extractor(pixel_mask, _roi_ids, image_shape):
     image_mask: np.ndarray
     """
     image_mask = np.zeros(list(image_shape)+[len(_roi_ids)])
-    for no, roi in enumerate(_roi_ids):
-        for x, y, wt in pixel_mask[roi]:
+    for no, rois in enumerate(_roi_ids):
+        for x, y, wt in pixel_mask[rois]:
             image_mask[int(x), int(y), no] = wt
     return image_mask
 

--- a/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -16,30 +16,27 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
     mode = 'file'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, filepath):
+    def __init__(self, file_path):
         """
         Parameters
         ----------
-        filepath: str
+        file_path: str
             The location of the folder containing dataset.mat file.
         """
         SegmentationExtractor.__init__(self)
-        self.filepath = filepath
+        self.file_path = file_path
         self._dataset_file, self._group0 = self._file_extractor_read()
         self.image_masks = self._image_mask_extractor_read()
-        self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-        self._total_time = self._tot_exptime_extractor_read()
+        self._roi_response_raw = self._trace_extractor_read()
         self._raw_movie_file_location = self._raw_datafile_read()
-        self._sampling_frequency = self._roi_response.shape[1]/self._total_time
-        # file close:
-        # self._file_close()
+        self._sampling_frequency = self._roi_response_raw.shape[1]/self._tot_exptime_extractor_read()
+        self._image_correlation = self._summary_image_read()
 
-    def _file_close(self):
+    def __del__(self):
         self._dataset_file.close()
 
     def _file_extractor_read(self):
-        f = h5py.File(self.filepath, 'r')
+        f = h5py.File(self.file_path, 'r')
         _group0_temp = list(f.keys())
         _group0 = [a for a in _group0_temp if '#' not in a]
         return f, _group0
@@ -55,23 +52,23 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
         return self._dataset_file[self._group0[0]]['time']['totalTime'][0][0]
 
     def _summary_image_read(self):
-        summary_images_ = self._dataset_file[self._group0[0]]['Cn']
-        return np.array(summary_images_).T
+        summary_image = self._dataset_file[self._group0[0]]['Cn']
+        return np.array(summary_image).T
 
     def _raw_datafile_read(self):
         charlist = [chr(i) for i in self._dataset_file[self._group0[0]]['movieList'][:]]
         return ''.join(charlist)
 
     def get_accepted_list(self):
-        return list(range(self.no_rois))
+        return list(range(self.get_num_rois()))
 
     def get_rejected_list(self):
-        return [a for a in range(self.no_rois) if a not in set(self.get_accepted_list())]
+        return [a for a in range(self.get_num_rois()) if a not in set(self.get_accepted_list())]
 
     @property
     def roi_locations(self):
-        roi_location = np.ndarray([2, self.no_rois], dtype='int')
-        for i in range(self.no_rois):
+        roi_location = np.ndarray([2, self.get_num_rois()], dtype='int')
+        for i in range(self.get_num_rois()):
             temp = np.where(self.image_masks[:, :, i] == np.amax(self.image_masks[:, :, i]))
             roi_location[:, i] = np.array([np.median(temp[0]), np.median(temp[1])]).T
         return roi_location
@@ -82,10 +79,7 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
 
     # defining the abstract class enformed methods:
     def get_roi_ids(self):
-        return list(range(self.no_rois))
-
-    def get_images(self):
-        return {'Images': {'meanImg': self._summary_image_read()}}
+        return list(range(self.get_num_rois()))
 
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -16,30 +16,27 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
     mode = 'file'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, filepath):
+    def __init__(self, file_path):
         """
         Parameters
         ----------
-        filepath: str
+        file_path: str
             The location of the folder containing dataset.mat file.
         """
         SegmentationExtractor.__init__(self)
-        self.filepath = filepath
+        self.file_path = file_path
         self._dataset_file, self._group0 = self._file_extractor_read()
         self.image_masks = self._image_mask_extractor_read()
-        self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-        self._total_time = self._tot_exptime_extractor_read()
+        self._roi_response_raw = self._trace_extractor_read()
         self._raw_movie_file_location = self._raw_datafile_read()
-        self._sampling_frequency = self._roi_response.shape[1]/self._total_time
-        # file close:
-        # self._file_close()
+        self._sampling_frequency = self._roi_response_raw.shape[1]/self._tot_exptime_extractor_read()
+        self._image_correlation = self._summary_image_read()
 
-    def _file_close(self):
+    def __del__(self):
         self._dataset_file.close()
 
     def _file_extractor_read(self):
-        f = h5py.File(self.filepath, 'r')
+        f = h5py.File(self.file_path, 'r')
         _group0_temp = list(f.keys())
         _group0 = [a for a in _group0_temp if '#' not in a]
         return f, _group0
@@ -55,25 +52,25 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
         return self._dataset_file[self._group0[0]]['time']['totalTime'][0][0]
 
     def _summary_image_read(self):
-        summary_images_ = self._dataset_file[self._group0[0]]['info']['summary_image']
-        return np.array(summary_images_).T
+        summary_image = self._dataset_file[self._group0[0]]['info']['summary_image']
+        return np.array(summary_image).T
 
     def _raw_datafile_read(self):
         charlist = [chr(i) for i in self._dataset_file[self._group0[0]]['file'][:]]
         return ''.join(charlist)
 
     def get_accepted_list(self):
-        return list(range(self.no_rois))
+        return list(range(self.get_num_rois()))
 
     def get_rejected_list(self):
-        return [a for a in range(self.no_rois) if a not in set(self.get_accepted_list())]
+        return [a for a in range(self.get_num_rois()) if a not in set(self.get_accepted_list())]
 
     @property
     def roi_locations(self):
-        no_ROIs = self.no_rois
+        num_ROIs = self.get_num_rois()
         raw_images = self.image_masks
-        roi_location = np.ndarray([2, no_ROIs], dtype='int')
-        for i in range(no_ROIs):
+        roi_location = np.ndarray([2, num_ROIs], dtype='int')
+        for i in range(num_ROIs):
             temp = np.where(raw_images[:, :, i] == np.amax(raw_images[:, :, i]))
             roi_location[:, i] = np.array([np.median(temp[0]), np.median(temp[1])]).T
         return roi_location
@@ -84,10 +81,7 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
 
     # defining the abstract class enformed methods:
     def get_roi_ids(self):
-        return list(range(self.no_rois))
-
-    def get_images(self):
-        return {'Images': {'meanImg': self._summary_image_read()}}
+        return list(range(self.get_num_rois()))
     
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -26,11 +26,11 @@ class SimaSegmentationExtractor(SegmentationExtractor):
     mode = 'file'
     installation_mesg = "To use the SimaSegmentationExtractor install sima: \n\n pip install sima\n\n"  # error message when not installed
 
-    def __init__(self, filepath, sima_segmentation_label='auto_ROIs'):
+    def __init__(self, file_path, sima_segmentation_label='auto_ROIs'):
         """
         Parameters
         ----------
-        filepath: str
+        file_path: str
             The location of the folder containing dataset.sima file and the raw
             image file(s) (tiff, h5, .zip)
         sima_segmentation_label: str
@@ -38,16 +38,15 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         """
         assert HAVE_SIMA, self.installation_mesg
         SegmentationExtractor.__init__(self)
-        self.filepath = filepath
-        self._convert_sima(filepath)
+        self.file_path = file_path
+        self._convert_sima(file_path)
         self._dataset_file = self._file_extractor_read()
         self._channel_names = [str(i) for i in self._dataset_file.channel_names]
-        self._no_of_channels = len(self._channel_names)
+        self._num_of_channels = len(self._channel_names)
         self.sima_segmentation_label = sima_segmentation_label
         self.image_masks = self._image_mask_extractor_read()
-        self._roi_response = self._trace_extractor_read()
-        self._roi_response_dict = {'Fluorescence': self._roi_response}
-
+        self._roi_response_raw = self._trace_extractor_read()
+        self._image_mean = self._summary_image_read()
 
     @staticmethod
     def _convert_sima(old_pkl_loc):
@@ -92,8 +91,8 @@ class SimaSegmentationExtractor(SegmentationExtractor):
                         pickle.dump(loaded, outfile)
 
     def _file_extractor_read(self):
-        _img_dataset = sima.ImagingDataset.load(self.filepath)
-        _img_dataset._savedir = self.filepath
+        _img_dataset = sima.ImagingDataset.load(self.file_path)
+        _img_dataset._savedir = self.file_path
         return _img_dataset
 
     def _image_mask_extractor_read(self):
@@ -119,7 +118,7 @@ class SimaSegmentationExtractor(SegmentationExtractor):
                     _active_channel = channel_now
                     break
             print('extracting signal from channel {} from {} no of channels'.
-                  format(_active_channel, self._no_of_channels))
+                  format(_active_channel, self._num_of_channels))
         # label for the extraction method in SIMA:
         for labels in self._dataset_file.signals(channel=_active_channel):
             _count = 0
@@ -137,21 +136,21 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         return extracted_signals
 
     def _summary_image_read(self):
-        summary_images_ = np.squeeze(self._dataset_file.time_averages[0]).T
-        return np.array(summary_images_).T
+        summary_image = np.squeeze(self._dataset_file.time_averages[0]).T
+        return np.array(summary_image).T
 
     def get_accepted_list(self):
-        return list(range(self.no_rois))
+        return list(range(self.get_num_rois()))
 
     def get_rejected_list(self):
-        return [a for a in range(self.no_rois) if a not in set(self.get_accepted_list())]
+        return [a for a in range(self.get_num_rois()) if a not in set(self.get_accepted_list())]
 
     @property
     def roi_locations(self):
-        no_ROIs = self.no_rois
+        num_ROIs = self.get_num_rois()
         raw_images = self.image_masks
-        roi_location = np.ndarray([2, no_ROIs], dtype='int')
-        for i in range(no_ROIs):
+        roi_location = np.ndarray([2, num_ROIs], dtype='int')
+        for i in range(num_ROIs):
             temp = np.where(raw_images[:, :, i] == np.amax(raw_images[:, :, i]))
             roi_location[:, i] = np.array([np.median(temp[0]), np.median(temp[1])]).T
         return roi_location
@@ -162,13 +161,7 @@ class SimaSegmentationExtractor(SegmentationExtractor):
 
     # defining the abstract class enformed methods:
     def get_roi_ids(self):
-        return list(range(self.no_rois))
-
-    def get_images(self):
-        out = {'Images': dict()}
-        for j,i in enumerate(self._channel_names):
-            out['Images'].update({f'meanImg_{i}': self._summary_image_read()[:,:,j]})
-        return out
+        return list(range(self.get_num_rois()))
 
     def get_image_size(self):
         return self.image_masks.shape[0:2]

--- a/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -27,24 +27,22 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
         SegmentationExtractor.__init__(self)
         self.combined = combined
         self.plane_no = plane_no
-        self.filepath = fileloc
+        self.file_path = fileloc
         self.stat = self._load_npy('stat.npy')
-        self.F = self._load_npy('F.npy', mmap_mode='r')
-        self.Fneu = self._load_npy('Fneu.npy', mmap_mode='r')
-        self.spks = self._load_npy('spks.npy', mmap_mode='r')
+        self._roi_response_raw = self._load_npy('F.npy', mmap_mode='r')
+        self._roi_response_neuropil = self._load_npy('Fneu.npy', mmap_mode='r')
+        self._roi_response_deconvolved = self._load_npy('spks.npy', mmap_mode='r')
         self.iscell = self._load_npy('iscell.npy', mmap_mode='r')
         self.ops = self._load_npy('ops.npy').item()
         self._channel_names = [f'OpticalChannel{i}' for i in range(self.ops['nchannels'])]
-        self._roi_response = self.F
-        self._roi_response_dict = {'Fluorescence': self.F,
-                               'Neuropil': self.Fneu,
-                               'Deconvolved': self.spks}
         self._sampling_frequency = self.ops['fs'] * [2 if self.combined else 1][0]
-        self._raw_movie_file_location = self.ops['filelist']
+        self._raw_movie_file_location = self.ops['filelist'][0]
         self.image_masks = self.get_roi_image_masks()
+        self._image_correlation = self._summary_image_read('Vcorr')
+        self._image_mean = self._summary_image_read('meanImg')
 
     def _load_npy(self, filename, mmap_mode=None):
-        fpath = os.path.join(self.filepath, f'Plane{self.plane_no}', filename)
+        fpath = os.path.join(self.file_path, f'Plane{self.plane_no}', filename)
         return np.load(fpath, mmap_mode=mmap_mode)
 
     def get_accepted_list(self):
@@ -52,6 +50,17 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
 
     def get_rejected_list(self):
         return np.where(self.iscell[:,0]==0)[0]
+
+    def _summary_image_read(self, bstr='meanImg'):
+        img = None
+        if bstr in self.ops:
+            if bstr == 'Vcorr' or bstr == 'max_proj':
+                img = np.zeros((self.ops['Ly'], self.ops['Lx']), np.float32)
+                img[self.ops['yrange'][0]:self.ops['yrange'][-1],
+                self.ops['xrange'][0]:self.ops['xrange'][-1]] = self.ops[bstr]
+            else:
+                img = self.ops[bstr]
+        return img
 
     @property
     def roi_locations(self):
@@ -63,44 +72,30 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
 
     # defining the abstract class enforced methods:
     def get_roi_ids(self):
-        return list(range(self.no_rois))
+        return list(range(self.get_num_rois()))
 
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
         else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
+            roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return _image_mask_extractor(self.get_roi_pixel_masks(roi_ids=roi_idx_), range(len(roi_idx_)), self.get_image_size())
 
     def get_roi_pixel_masks(self, roi_ids=None):
         pixel_mask = []
-        for i in range(self.no_rois):
+        for i in range(self.get_num_rois()):
             pixel_mask.append(np.vstack([self.stat[i]['ypix'],
                                       self.stat[i]['xpix'],
                                       self.stat[i]['lam']]).T)
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
         else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
+            roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
         return [pixel_mask[i] for i in roi_idx_]
-
-    def get_images(self):
-        bg_strs = ['meanImg', 'Vcorr', 'max_proj', 'meanImg_chan2']
-        out_dict = {'Images': {}}
-        for bstr in bg_strs:
-            if bstr in self.ops:
-                if bstr == 'Vcorr' or bstr == 'max_proj':
-                    img = np.zeros((self.ops['Ly'], self.ops['Lx']), np.float32)
-                    img[self.ops['yrange'][0]:self.ops['yrange'][-1],
-                    self.ops['xrange'][0]:self.ops['xrange'][-1]] = self.ops[bstr]
-                else:
-                    img = self.ops[bstr]
-                out_dict['Images'].update({bstr: img})
-        return out_dict
 
     def get_image_size(self):
         return [self.ops['Lx'], self.ops['Ly']]

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -4,7 +4,6 @@ import numpy as np
 from .extraction_tools import ArrayType
 from .extraction_tools import _pixel_mask_extractor
 from copy import deepcopy
-import warnings
 
 
 class SegmentationExtractor(ABC, BaseExtractor):
@@ -199,7 +198,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         return deepcopy(dict(mean=self._image_mean,
                              correlation=self._image_correlation))
 
-    def get_images(self, name='correlation'):
+    def get_image(self, name='correlation'):
         """
         Return specific images: mean or correlation
         Parameters

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -3,6 +3,8 @@ from spikeextractors.baseextractor import BaseExtractor
 import numpy as np
 from .extraction_tools import ArrayType
 from .extraction_tools import _pixel_mask_extractor
+from copy import deepcopy
+import warnings
 
 
 class SegmentationExtractor(ABC, BaseExtractor):
@@ -18,79 +20,14 @@ class SegmentationExtractor(ABC, BaseExtractor):
     def __init__(self):
         BaseExtractor.__init__(self)
         self._sampling_frequency = None
-
-    @property
-    def image_size(self):
-        """
-        Returns
-        -------
-        image_dims: list
-            The width X height of the image.
-        """
-        return self.get_image_size()
-
-    @property
-    def no_rois(self):
-        """
-        The number of Independent sources(neurons) identified after the
-        segmentation operation. The regions of interest for which fluorescence
-        traces will be extracted downstream.
-
-        Returns
-        -------
-        no_rois: int
-            The number of rois
-        """
-        return self.get_num_rois()
-
-    @property
-    def roi_ids(self):
-        """
-        Integer label given to each region of interest (neuron).
-
-        Returns
-        -------
-        roi_idx: list
-            list of integers of the ROIs. Listed in the order in which the ROIs
-            occur in the image_masks (2nd dimention)
-        """
-        return self.get_roi_ids()
-
-    @property
-    def roi_locations(self):
-        """
-        The x and y pixel location of the ROIs. The location where the pixel
-        value is maximum in the image mask.
-
-        Returns
-        -------
-        roi_locs: np.array
-            Array with the first row representing the y (height) and second representing
-            the x (width) coordinates of the ROI.
-        """
-        return self.get_roi_locations()
-
-    @property
-    def num_frames(self):
-        """
-        Total number of images in the image sequence across time.
-
-        Returns
-        -------
-        num_of_frames: int
-            Same as the -1 dimention of the dF/F trace(roi_response).
-        """
-        return self.get_num_frames()
-
-    @property
-    def sampling_frequency(self):
-        """
-        Returns
-        -------
-        samp_freq: int
-            Sampling frequency of the dF/F trace.
-        """
-        return self._sampling_frequency
+        self._channel_names = ['OpticalChannel']
+        self._num_planes = 1
+        self._roi_response_raw = None
+        self._roi_response_dff = None
+        self._roi_response_neuropil = None
+        self._roi_response_deconvolved = None
+        self._image_correlation = None
+        self._image_mean = None
 
     @abstractmethod
     def get_accepted_list(self) -> list:
@@ -126,7 +63,9 @@ class SegmentationExtractor(ABC, BaseExtractor):
         num_of_frames: int
             Number of frames in the recording (duration of recording).
         """
-        return self._roi_response.shape[1]
+        for trace in self.get_traces_dict().values():
+            if len(trace.shape)>0:
+                return trace.shape[1]
 
     def get_roi_locations(self, roi_ids=None) -> np.array:
         """
@@ -146,7 +85,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         if roi_ids is None:
             return self.roi_locations
         else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
+            roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
             return self.roi_locations[:, roi_idx_]
@@ -179,10 +118,10 @@ class SegmentationExtractor(ABC, BaseExtractor):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
         else:
-            roi_idx = [np.where(np.array(i) == self.roi_ids)[0] for i in roi_ids]
+            roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        return self.image_masks[:, :, roi_idx_]
+        return np.array(self.image_masks)[:, :, roi_idx_]
 
     def get_roi_pixel_masks(self, roi_ids=None) -> np.array:
         """
@@ -215,7 +154,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         pass
 
-    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name='Fluorescence'):
+    def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name='raw'):
         """
         Return RoiResponseSeries
         Returns
@@ -223,16 +162,57 @@ class SegmentationExtractor(ABC, BaseExtractor):
         traces: array_like
             2-D array (ROI x timepoints)
         """
-        if name not in self._roi_response_dict:
-            raise ValueError(f'traces for {name} not found, enter one of {list(self._roi_response_dict.keys())}')
+        if name not in self.get_traces_dict():
+            raise ValueError(f'traces for {name} not found, enter one of {list(self.get_traces_dict().keys())}')
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())
         else:
             roi_idx = [np.where(np.array(i) == self.get_roi_ids())[0] for i in roi_ids]
             ele = [i for i, j in enumerate(roi_idx) if j.size == 0]
             roi_idx_ = [j[0] for i, j in enumerate(roi_idx) if i not in ele]
-        traces = self._roi_response_dict.get(name)
+        traces = self.get_traces_dict().get(name)
         return np.array([traces[int(i), start_frame:end_frame] for i in roi_idx_])
+
+    def get_traces_dict(self):
+        """
+        Returns traces as a dictionary with key as the name of the ROiResponseSeries
+        Returns
+        -------
+        _roi_response_dict: dict
+            dictionary with key, values representing different types of RoiResponseSeries
+            Flourescence, Neuropil, Deconvolved, Background etc
+        """
+        return deepcopy(dict(raw=np.array(self._roi_response_raw),
+                             dff=np.array(self._roi_response_dff),
+                             neuropil=np.array(self._roi_response_neuropil),
+                             deconvolved=np.array(self._roi_response_deconvolved)))
+
+    def get_images_dict(self):
+        """
+        Returns traces as a dictionary with key as the name of the ROiResponseSeries
+        Returns
+        -------
+        _roi_response_dict: dict
+            dictionary with key, values representing different types of Images used in segmentation:
+            Mean, Correlation image
+        """
+        return deepcopy(dict(mean=self._image_mean,
+                             correlation=self._image_correlation))
+
+    def get_images(self, name='correlation'):
+        """
+        Return specific images: mean or correlation
+        Parameters
+        ----------
+        name:str
+            name of the type of image to retrieve
+        Returns
+        -------
+        images: np.ndarray
+        """
+        if name not in self.get_images_dict():
+            raise ValueError(f'could not find {name} image, enter one of {list(self.get_images_dict().keys())}')
+        return self.get_images_dict().get(name)
 
     def get_sampling_frequency(self):
         """This function returns the sampling frequency in units of Hz.
@@ -252,22 +232,38 @@ class SegmentationExtractor(ABC, BaseExtractor):
         no_rois: int
             integer number of ROIs extracted.
         """
-        return self._roi_response.shape[0]
+        for trace in self.get_traces_dict().values():
+            if len(trace.shape)>0:
+                return trace.shape[0]
 
-    def get_images(self):
+    def get_channel_names(self):
         """
-        Retrieve any relevant greyscale images from the pipeline
-
+        Names of channels in the pipeline
         Returns
         -------
-        image_dict: dict
-            Keys as a list of dictionaries. Structure of the dictionary:
-            <image_group_name>:
-                -<image_name1>: <image_data1>
-                -<image_name2>: <image_data2>
-                -<image_name3>: <image_data3>
+        _channel_names: list
+            names of channels (str)
         """
-        raise NotImplementedError
+        return self._channel_names
+
+    def get_num_channels(self):
+        """
+        Number of channels in the pipeline
+        Returns
+        -------
+        num_of_channels: int
+        """
+        return len(self._channel_names)
+
+    def get_num_planes(self):
+        """
+        Returns the default number of planes of imaging for the segmentation extractor.
+        Detaults to 1 for all but the MultiSegmentationExtractor
+        Returns
+        -------
+        self._num_planes: int
+        """
+        return self._num_planes
 
     @staticmethod
     def write_segmentation(segmentation_extractor, savepath):


### PR DESCRIPTION
There are a fair bit of change in this PR, will it be better to break it into 2 parts? 

Here are the changes: 
1. Images attributes: `self._image_raw`, `self._image_correlation`, these are subsequently packed into a dict using `self.get_images_dict()`
2. Traces attributes: `self._roi_response_raw`, `self._roi_response_dff`,  `self._roi_response_neuropil,` `self._roi_response_deconvolved`, these are then packed into dict using `self.get_traces_dict()`
3. all the property methods are removed from segmentationextractor base class. 
4. Renaming for more clarity: `filepath` > `file_path,` `no_of_channels` to `num_of_channels`