### PR TITLE
Implemented write_imaging methods for ImagingExtractors

### DIFF
--- a/roiextractors/example_datasets/toy_example.py
+++ b/roiextractors/example_datasets/toy_example.py
@@ -114,7 +114,7 @@ def toy_example(duration=10, num_rois=10, size_x=100, size_y=100, roi_size=4, mi
     # convolve response with ROIs
     raw = np.zeros((len(sort.get_unit_ids()), rec.get_num_frames()))
     deconvolved = np.zeros((len(sort.get_unit_ids()), rec.get_num_frames()))
-    neuropil = noise_std * np.random.randn((len(sort.get_unit_ids()), rec.get_num_frames()))
+    neuropil = noise_std * np.random.randn(len(sort.get_unit_ids()), rec.get_num_frames())
     frames = rec.get_num_frames()
     for u_i, unit in enumerate(sort.get_unit_ids()):
         for s in sort.get_unit_spike_train(unit):

--- a/roiextractors/example_datasets/toy_example.py
+++ b/roiextractors/example_datasets/toy_example.py
@@ -118,11 +118,12 @@ def toy_example(duration=10, num_rois=10, size_x=100, size_y=100, roi_size=4, mi
     frames = rec.get_num_frames()
     for u_i, unit in enumerate(sort.get_unit_ids()):
         for s in sort.get_unit_spike_train(unit):
-            if s + len(resp) < frames:
-                raw[u_i, s:s + len(resp)] += resp
-            else:
-                raw[u_i, s:] = resp[:frames - s]
-            deconvolved[u_i, s] = 1
+            if s < rec.get_num_frames():
+                if s + len(resp) < frames:
+                    raw[u_i, s:s + len(resp)] += resp
+                else:
+                    raw[u_i, s:] = resp[:frames - s]
+                deconvolved[u_i, s] = 1
 
     # generate video
     video = np.zeros((frames, size_x, size_y))

--- a/roiextractors/extraction_tools.py
+++ b/roiextractors/extraction_tools.py
@@ -86,7 +86,6 @@ def get_video_shape(video):
 def check_get_frames_args(func):
     @wraps(func)
     def corrected_args(imaging, frame_idxs, channel=0):
-        print(type(frame_idxs))
         channel = int(channel)
         if isinstance(frame_idxs, (int, np.integer)):
             frame_idxs = [frame_idxs]
@@ -182,7 +181,6 @@ def write_to_h5_dataset_format(imaging, dataset_path, save_path=None, file_handl
     # set chunk size
     if chunk_size is not None:
         chunk_size = int(chunk_size)
-
     elif chunk_mb is not None:
         n_bytes = np.dtype(imaging.get_dtype()).itemsize
         max_size = int(chunk_mb * 1e6)  # set Mb per chunk
@@ -194,7 +192,7 @@ def write_to_h5_dataset_format(imaging, dataset_path, save_path=None, file_handl
             video = imaging.get_video(channel=ch)
             if dtype is not None:
                 video = video.astype(dtype_file)
-            dset[ch, :] = np.squeeze(video)
+            dset[ch, ...] = np.squeeze(video)
         else:
             chunk_start = 0
             # chunk size is not None
@@ -211,7 +209,7 @@ def write_to_h5_dataset_format(imaging, dataset_path, save_path=None, file_handl
                 chunk_frames = np.squeeze(video).shape[0]
                 if dtype is not None:
                     video = video.astype(dtype_file)
-                dset[ch, chunk_start:chunk_start + chunk_frames, :] = video
+                dset[ch, chunk_start:chunk_start + chunk_frames, ...] = np.squeeze(video)
                 chunk_start += chunk_frames
 
     if save_path is not None:

--- a/roiextractors/extraction_tools.py
+++ b/roiextractors/extraction_tools.py
@@ -2,7 +2,14 @@ import numpy as np
 from typing import Union
 from pathlib import Path
 from functools import wraps
+from tqdm import tqdm
 from spikeextractors.extraction_tools import cast_start_end_frame
+
+try:
+    import h5py
+    HAVE_H5 = True
+except ImportError:
+    HAVE_H5 = False
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]
@@ -79,13 +86,13 @@ def get_video_shape(video):
 def check_get_frames_args(func):
     @wraps(func)
     def corrected_args(imaging, frame_idxs, channel=0):
+        print(type(frame_idxs))
         channel = int(channel)
         if isinstance(frame_idxs, (int, np.integer)):
             frame_idxs = [frame_idxs]
-
         if not isinstance(frame_idxs, slice):
             frame_idxs = np.array(frame_idxs)
-        assert np.all(frame_idxs < imaging.get_num_frames()), "'frame_idxs' exceed number of frames"
+            assert np.all(frame_idxs < imaging.get_num_frames()), "'frame_idxs' exceed number of frames"
         get_frames_correct_arg = func(imaging, frame_idxs, channel)
 
         if len(frame_idxs) == 1:
@@ -120,6 +127,97 @@ def check_get_videos_args(func):
 
         return get_videos_correct_arg
     return corrected_args
+
+
+def write_to_h5_dataset_format(imaging, dataset_path, save_path=None, file_handle=None,
+                               dtype=None, chunk_size=None, chunk_mb=1000, verbose=False):
+    '''Saves the video of an imaging extractor in an h5 dataset.
+
+    Parameters
+    ----------
+    imaging: ImagingExtractor
+        The imaging extractor object to be saved in the .h5 filr
+    dataset_path: str
+        Path to dataset in h5 file (e.g. '/dataset')
+    save_path: str
+        The path to the file.
+    file_handle: file handle
+        The file handle to dump data. This can be used to append data to an header. In case file_handle is given,
+        the file is NOT closed after writing the binary data.
+    dtype: dtype
+        Type of the saved data. Default float32.
+    chunk_size: None or int
+        Number of chunks to save the file in. This avoid to much memory consumption for big files.
+        If None and 'chunk_mb' is given, the file is saved in chunks of 'chunk_mb' Mb (default 500Mb)
+    chunk_mb: None or int
+        Chunk size in Mb (default 1000Mb)
+    verbose: bool
+        If True, output is verbose (when chunks are used)
+    '''
+    assert HAVE_H5, "To write to h5 you need to install h5py: pip install h5py"
+    assert save_path is not None or file_handle is not None, "Provide 'save_path' or 'file handle'"
+
+    if save_path is not None:
+        save_path = Path(save_path)
+        if save_path.suffix == '':
+            # when suffix is already raw/bin/dat do not change it.
+            save_path = save_path.parent / (save_path.name + '.h5')
+
+    num_channels = imaging.get_num_channels()
+    num_frames = imaging.get_num_frames()
+    size_x, size_y = imaging.get_image_size()
+
+    if file_handle is not None:
+        assert isinstance(file_handle, h5py.File)
+    else:
+        file_handle = h5py.File(save_path, 'w')
+
+    if dtype is None:
+        dtype_file = imaging.get_dtype()
+    else:
+        dtype_file = dtype
+
+    dset = file_handle.create_dataset(dataset_path, shape=(num_channels, num_frames, size_x, size_y), dtype=dtype_file)
+
+    # set chunk size
+    if chunk_size is not None:
+        chunk_size = int(chunk_size)
+
+    elif chunk_mb is not None:
+        n_bytes = np.dtype(imaging.get_dtype()).itemsize
+        max_size = int(chunk_mb * 1e6)  # set Mb per chunk
+        chunk_size = max_size // (size_x * size_y * n_bytes)
+
+    # writ one channel at a time
+    for ch in range(num_channels):
+        if chunk_size is None:
+            video = imaging.get_video(channel=ch)
+            if dtype is not None:
+                video = video.astype(dtype_file)
+            dset[ch, :] = np.squeeze(video)
+        else:
+            chunk_start = 0
+            # chunk size is not None
+            n_chunk = num_frames // chunk_size
+            if num_frames % chunk_size > 0:
+                n_chunk += 1
+            if verbose:
+                chunks = tqdm(range(n_chunk), ascii=True, desc="Writing to .h5 file")
+            else:
+                chunks = range(n_chunk)
+            for i in chunks:
+                video = imaging.get_video(start_frame=i * chunk_size,
+                                          end_frame=min((i + 1) * chunk_size, num_frames), channel=ch)
+                chunk_frames = np.squeeze(video).shape[0]
+                if dtype is not None:
+                    video = video.astype(dtype_file)
+                dset[ch, chunk_start:chunk_start + chunk_frames, :] = video
+                chunk_start += chunk_frames
+
+    if save_path is not None:
+        file_handle.close()
+    return save_path
+
 
 # TODO will be moved eventually, but for now it's very handy :)
 def show_video(imaging, ax=None):

--- a/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -71,14 +71,15 @@ class Hdf5ImagingExtractor(ImagingExtractor):
 
     @check_get_frames_args
     def get_frames(self, frame_idxs, channel=0):
-        if frame_idxs.size > 1 and np.all(np.diff(frame_idxs) > 0):
-            # return lazy_ops.DatasetView(self._video).lazy_slice[channel, frame_idxs]
-            return self._video[channel, frame_idxs]
+        if frame_idxs.size > 1 and np.all(np.diff(frame_idxs) > 0) or frame_idxs.size == 1:
+            return lazy_ops.DatasetView(self._video).lazy_slice[channel, frame_idxs]
+            # return self._video[channel, frame_idxs]
         else:
+            # unsorted multiple frame idxs
             sorted_idxs = np.sort(frame_idxs)
             argsorted_idxs = np.argsort(frame_idxs)
-            return self._video[channel, sorted_idxs][:, argsorted_idxs]
-            # return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
+            # return self._video[channel, sorted_idxs][:, argsorted_idxs]
+            return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
 
     def get_image_size(self):
         return [self._size_x, self._size_y]

--- a/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -72,14 +72,14 @@ class Hdf5ImagingExtractor(ImagingExtractor):
     @check_get_frames_args
     def get_frames(self, frame_idxs, channel=0):
         if frame_idxs.size > 1 and np.all(np.diff(frame_idxs) > 0) or frame_idxs.size == 1:
-            return lazy_ops.DatasetView(self._video).lazy_slice[channel, frame_idxs]
-            # return self._video[channel, frame_idxs]
+            return self._video[channel, frame_idxs]
+            # return lazy_ops.DatasetView(self._video).lazy_slice[channel, frame_idxs]
         else:
             # unsorted multiple frame idxs
             sorted_idxs = np.sort(frame_idxs)
             argsorted_idxs = np.argsort(frame_idxs)
-            # return self._video[channel, sorted_idxs][:, argsorted_idxs]
-            return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
+            return self._video[channel, sorted_idxs][:, argsorted_idxs]
+            # return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
 
     def get_image_size(self):
         return [self._size_x, self._size_y]

--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -81,9 +81,15 @@ class NumpyImagingExtractor(ImagingExtractor):
         return self._num_channels
 
     @staticmethod
-    def write_imaging(imaging, save_path):
+    def write_imaging(imaging, save_path, overwrite: bool = False):
         save_path = Path(save_path)
         assert save_path.suffix == '.npy', "'save_path' should havve a .npy extension"
+
+        if save_path.is_file():
+            if not overwrite:
+                raise FileExistsError("The specified path exists! Use overwrite=True to overwrite it.")
+            else:
+                save_path.unlink()
 
         np.save(save_path, imaging.get_video())
 

--- a/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
+++ b/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
@@ -1,5 +1,6 @@
 import numpy as np
 from pathlib import Path
+from tqdm import tqdm
 from ...imagingextractor import ImagingExtractor
 from ...extraction_tools import PathType, get_video_shape, check_get_frames_args
 
@@ -80,7 +81,7 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._num_channels
 
     @staticmethod
-    def write_imaging(imaging, save_path, overwrite: bool=False):
+    def write_imaging(imaging, save_path, overwrite: bool = False, chunk_size=None, verbose=True):
         save_path = Path(save_path)
         assert save_path.suffix in ['.tiff', '.tif', '.TIFF', '.TIF'], "'save_path' file is not an .tiff file"
 
@@ -90,5 +91,24 @@ class TiffImagingExtractor(ImagingExtractor):
             else:
                 save_path.unlink()
 
-        # TODO chunk this
-        tifffile.imsave(save_path, imaging.get_video())
+        if chunk_size is None:
+            tifffile.imsave(save_path, imaging.get_video())
+        else:
+            raise NotImplementedError("Writing tiff file in chunks is currently not implemented")
+            # num_frames = imaging.get_num_frames()
+            # chunk_start = 0
+            # # chunk size is not None
+            # n_chunk = num_frames // chunk_size
+            # if num_frames % chunk_size > 0:
+            #     n_chunk += 1
+            # if verbose:
+            #     chunks = tqdm(range(n_chunk), ascii=True, desc="Writing to .tiff file")
+            # else:
+            #     chunks = range(n_chunk)
+            # for i in chunks:
+            #     video = imaging.get_video(start_frame=i * chunk_size,
+            #                               end_frame=min((i + 1) * chunk_size, num_frames))
+            #     chunk_frames = np.squeeze(video)
+            #     tifffile.imsave(save_path, chunk_frames, append=True)
+            #     chunk_start += chunk_frames
+

--- a/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
+++ b/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
@@ -24,7 +24,7 @@ class TiffImagingExtractor(ImagingExtractor):
         self.file_path = Path(file_path)
         self._sampling_frequency = sampling_frequency
         self._channel_names = channel_names
-        assert self.file_path.suffix in ['.tiff', '.tif']
+        assert self.file_path.suffix in ['.tiff', '.tif', '.TIFF', '.TIF']
 
         with tifffile.TiffFile(self.file_path) as tif:
             self._num_channels = len(tif.series)
@@ -80,5 +80,15 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._num_channels
 
     @staticmethod
-    def write_imaging(imaging, savepath):
-        pass
+    def write_imaging(imaging, save_path, overwrite: bool=False):
+        save_path = Path(save_path)
+        assert save_path.suffix in ['.tiff', '.tif', '.TIFF', '.TIF'], "'save_path' file is not an .tiff file"
+
+        if save_path.is_file():
+            if not overwrite:
+                raise FileExistsError("The specified path exists! Use overwrite=True to overwrite it.")
+            else:
+                save_path.unlink()
+
+        # TODO chunk this
+        tifffile.imsave(save_path, imaging.get_video())

--- a/roiextractors/imagingextractor.py
+++ b/roiextractors/imagingextractor.py
@@ -59,7 +59,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         return self.get_frames(range(start_frame, end_frame), channel)
 
     @staticmethod
-    def write_imaging(imaging, save_path: PathType):
+    def write_imaging(imaging, save_path: PathType, overwrite: bool = False):
         """
         Static method to write imaging.
 
@@ -70,6 +70,8 @@ class ImagingExtractor(ABC, BaseExtractor):
             file has to be generated.
         save_path: str
             path to save the native format.
+        overwrite: bool
+            If True and save_path is existing, it is overwritten
         """
         raise NotImplementedError
 

--- a/roiextractors/memmapextractors.py
+++ b/roiextractors/memmapextractors.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pathlib import Path
 from .imagingextractor import ImagingExtractor
-from .extraction_tools import PathType
+from .extraction_tools import PathType, check_get_frames_args
 import os
 import tempfile
 import shutil
@@ -49,12 +49,12 @@ class MemmapImagingExtractor(ImagingExtractor):
             for ch in range(self.imaging.get_num_channels()):
                 print(f"Saving channel {ch}")
                 for i in tqdm(range(self.imaging.get_num_frames())):
-                    plane = self.imaging.get_frame(i, channel=ch)
+                    plane = self.imaging.get_frames(i, channel=ch)
                     self._video[ch, i] = plane
         else:
             for ch in range(self.imaging.get_num_channels()):
                 for i in range(self.imaging.get_num_frames()):
-                    plane = self.imaging.get_frame(i, channel=ch)
+                    plane = self.imaging.get_frames(i, channel=ch)
                     self._video[ch, i] = plane
 
     @property
@@ -75,25 +75,10 @@ class MemmapImagingExtractor(ImagingExtractor):
                                                   self.imaging.get_image_size()[0]),
                                 dtype=self.imaging.get_dtype(), mode='r')
 
-    def get_frame(self, frame_idx, channel=0):
-        assert frame_idx < self.get_num_frames()
-        return self._video[channel, frame_idx]
 
+    @check_get_frames_args
     def get_frames(self, frame_idxs, channel=0):
-        assert np.all(frame_idxs < self.get_num_frames())
         return self._video[channel, frame_idxs]
-
-    # TODO make decorator to check and correct inputs
-    def get_video(self, start_frame=None, end_frame=None, channel=0):
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        end_frame = min(end_frame, self.get_num_frames())
-
-        video = self._video[channel, start_frame: end_frame]
-
-        return video
 
     def get_image_size(self):
         return self.imaging.get_image_size()


### PR DESCRIPTION
- Implemented/improved writers for:
    - `Hdf5ImagingExtractor`
    - `NpyImagingExtractor`
    - `TiffImagingExtractor`

- Fixed some bugs in `MemmapImagingExtractor`
- Fix to toy example if a spike occurs at the last frame (a spikeextractor error apparently)

Issues: 
- @bendichter somehow the `lazy_slice` from `lazy_ops` is failing with a: 
`IndexError: Indices must be either integers, iterators of integers, slice objects, or numpy boolean arrays`
even if all indeces are int ot arrays of int.. any ideas? I also tried slices with the same outcome.

- The tiff writing is not memory efficient (using the `get_video()`). The `tifffile.imsave()` method supports only numpy array as input, so in case we want/need chunking we have to implemet it ourself (maybe using `tifffile` to write the header and dump the video in binary format in chunks at the right place

Both these issues could be addressed properly later!