### PR TITLE
ENH: install datalad systemwide via apt

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
+        sudo apt-get install -y datalad
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Install roiextractors


### PR DESCRIPTION
This should provide good enough version to install datasets.
A more recent version, including a more recent git-annex is available
from neurodebian and conda-forge if conda is used.  But for now
this should suffice AFAIK