### PR TITLE
Added set_times to imaging and nwb writer

### DIFF
--- a/roiextractors/example_datasets/toy_example.py
+++ b/roiextractors/example_datasets/toy_example.py
@@ -74,7 +74,7 @@ def toy_example(
     roi_size=4,
     min_dist=5,
     mode="uniform",
-    sampling_frequency=30,
+    sampling_frequency=30.,
     decay_time=0.5,
     noise_std=0.05,
 ):
@@ -181,7 +181,7 @@ def toy_example(
         raw=raw,
         deconvolved=deconvolved,
         neuropil=neuropil,
-        sampling_frequency=sampling_frequency,
+        sampling_frequency=float(sampling_frequency),
     )
 
     return imag, seg

--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -10,7 +10,9 @@ from ...segmentationextractor import SegmentationExtractor
 
 class NumpyImagingExtractor(ImagingExtractor):
     extractor_name = "NumpyImagingExtractor"
+    installed = True
     is_writable = True
+    installation_mesg = ""  # error message when not installed
 
     def __init__(
         self,

--- a/roiextractors/imagingextractor.py
+++ b/roiextractors/imagingextractor.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+from typing import Union
+import numpy as np
+from copy import deepcopy
 
 from spikeextractors.baseextractor import BaseExtractor
 
@@ -70,37 +73,66 @@ class ImagingExtractor(ABC, BaseExtractor):
     ) -> NumpyArray:
         return self.get_frames(range(start_frame, end_frame), channel)
 
-    def frame_to_time(self, frame: IntType):
-        """This function converts a user-inputted frame index to a time with units of seconds.
+    def frame_to_time(self, frames: Union[FloatType, NumpyArray]) -> Union[FloatType, NumpyArray]:
+        """This function converts user-inputted frame indexes to times with units of seconds.
 
         Parameters
         ----------
-        frame: float
-            The frame to be converted to a time
+        frames: int or array-like
+            The frame or frames to be converted to times
 
         Returns
         -------
-        time: float
-            The corresponding time in seconds
+        times: float or array-like
+            The corresponding times in seconds
         """
         # Default implementation
-        return frame / self.get_sampling_frequency()
+        if self._times is None:
+            return np.round(frames / self.get_sampling_frequency(), 6)
+        else:
+            return self._times[frames]
 
-    def time_to_frame(self, time: FloatType):
-        """This function converts a user-inputted time (in seconds) to a frame index.
+    def time_to_frame(self, times: Union[FloatType, NumpyArray]) -> Union[FloatType, NumpyArray]:
+        """This function converts a user-inputted times (in seconds) to a frame indexes.
 
         Parameters
         -------
-        time: float
-            The time (in seconds) to be converted to frame index
+        times: float or array-like
+            The times (in seconds) to be converted to frame indexes
 
         Returns
         -------
-        frame: float
-            The corresponding frame index
+        frames: float or array-like
+            The corresponding frame indexes
         """
         # Default implementation
-        return time * self.get_sampling_frequency()
+        if self._times is None:
+            return np.round(times * self.get_sampling_frequency()).astype('int64')
+        else:
+            return np.searchsorted(self._times, times).astype('int64')
+    
+    def set_times(self, times : NumpyArray):
+        """This function sets the recording times (in seconds) for each frame
+
+        Parameters
+        ----------
+        times: array-like
+            The times in seconds for each frame
+        """
+        assert len(times) == self.get_num_frames(), "'times' should have the same length of the " \
+                                                    "number of frames"
+        self._times = times.astype('float64')
+
+    def copy_times(self, extractor : BaseExtractor):
+        """This function copies times from another extractor.
+
+        Parameters
+        ----------
+        extractor: BaseExtractor
+            The extractor from which the epochs will be copied
+        """
+        if extractor._times is not None:
+            self.set_times(deepcopy(extractor._times))
 
     @staticmethod
     def write_imaging(imaging, save_path: PathType, overwrite: bool = False):

--- a/roiextractors/testing.py
+++ b/roiextractors/testing.py
@@ -155,10 +155,12 @@ def check_imaging_equal(img1: ImagingExtractor, img2: ImagingExtractor):
     # assert equality:
     assert img1.get_num_frames() == img2.get_num_frames()
     assert img1.get_num_channels() == img2.get_num_channels()
-    assert img1.get_sampling_frequency() == img2.get_sampling_frequency()
+    assert np.isclose(img1.get_sampling_frequency(), img2.get_sampling_frequency())
     assert_array_equal(img1.get_channel_names(), img2.get_channel_names())
     assert_array_equal(img1.get_image_size(), img2.get_image_size())
     assert_array_equal(img1.get_frames(frame_idxs=[0]), img2.get_frames(frame_idxs=[0]))
+    assert_array_equal(img1.frame_to_time(np.arange(img1.get_num_frames())), 
+                       img2.frame_to_time(np.arange(img2.get_num_frames())))
 
 
 def check_imaging_return_types(img_ex: ImagingExtractor):
@@ -182,6 +184,6 @@ def check_imaging_return_types(img_ex: ImagingExtractor):
     _assert_iterable_complete(
         img_ex.get_frames(frame_idxs=[0, 1]),
         dtypes=(np.ndarray,),
-        element_dtypes=inttype,
+        element_dtypes=inttype + floattype,
         shape=(2, *img_ex.get_image_size()),
     )

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+import numpy as np
 from pathlib import Path
 
 from datalad.api import install, Dataset
@@ -16,6 +17,7 @@ from roiextractors import (
     SbxImagingExtractor,
     NwbImagingExtractor,
 )
+from roiextractors.example_datasets import toy_example
 from roiextractors.testing import check_segmentations_equal, check_imaging_equal
 
 
@@ -151,6 +153,20 @@ class TestNwbConversions(unittest.TestCase):
         img_ex_rt = roi_ex_class(
             file_path=rt_read_path, sampling_frequency=sampling_freq
         )
+        
+    def test_use_times(self):
+        imag, _ = toy_example(duration=10, num_rois=2)
+        
+        timestamps = imag.frame_to_time(np.arange(imag.get_num_frames())) + 0.5
+        imag.set_times(timestamps)
+        
+        save_path = "timestamps.nwb"
+        
+        NwbImagingExtractor.write_imaging(imag, save_path=save_path,
+                                          use_times=True, overwrite=True)
+        nwbimag = NwbImagingExtractor(save_path)
+        check_imaging_equal(imag, nwbimag)
+        
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added the possibility to set timestamps to the `ImagingExtractor` object, which are also converted to NWB as `timestamps` of the `TwoPhotonSeries`.

Implements request https://github.com/catalystneuro/roiextractors/issues/52