### PR TITLE
Fix NumpySegmentationExtractor

### DIFF
--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -234,28 +234,34 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             self.is_dumpable = False
             self._image_masks = image_masks
             self._roi_response_raw = raw
-            assert self._image_masks.shape[2] == len(
-                self._roi_response_raw), ("Inconsistency between image masks and raw traces. "
-                                          "Image masks must be (px, py, num_rois), "
-                                          "traces must be (num_rois, num_frames)")
+            assert self._image_masks.shape[2] == len(self._roi_response_raw), (
+                "Inconsistency between image masks and raw traces. "
+                "Image masks must be (px, py, num_rois), "
+                "traces must be (num_rois, num_frames)"
+            )
             self._roi_response_dff = dff
             if self._roi_response_dff is not None:
-                assert self._image_masks.shape[2] == len(
-                    self._roi_response_dff), ("Inconsistency between image masks and raw traces. "
-                                              "Image masks must be (px, py, num_rois), "
-                                              "traces must be (num_rois, num_frames)")
+                assert self._image_masks.shape[2] == len(self._roi_response_dff), (
+                    "Inconsistency between image masks and raw traces. "
+                    "Image masks must be (px, py, num_rois), "
+                    "traces must be (num_rois, num_frames)"
+                )
             self._roi_response_neuropil = neuropil
             if self._roi_response_neuropil is not None:
-                assert self._image_masks.shape[2] == len(
-                    self._roi_response_neuropil), ("Inconsistency between image masks and raw traces. "
-                                                   "Image masks must be (px, py, num_rois), "
-                                                   "traces must be (num_rois, num_frames)")
+                assert self._image_masks.shape[2] == len(self._roi_response_neuropil), (
+                    "Inconsistency between image masks and raw traces. "
+                    "Image masks must be (px, py, num_rois), "
+                    "traces must be (num_rois, num_frames)"
+                )
             self._roi_response_deconvolved = deconvolved
             if self._roi_response_deconvolved is not None:
                 assert self._image_masks.shape[2] == len(
-                    self._roi_response_deconvolved), ("Inconsistency between image masks and raw traces. "
-                                                      "Image masks must be (px, py, num_rois), "
-                                                      "traces must be (num_rois, num_frames)")
+                    self._roi_response_deconvolved
+                ), (
+                    "Inconsistency between image masks and raw traces. "
+                    "Image masks must be (px, py, num_rois), "
+                    "traces must be (num_rois, num_frames)"
+                )
             self._kwargs = {
                 "image_masks": image_masks,
                 "signal": raw,
@@ -271,7 +277,9 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         if roi_ids is None:
             self._roi_ids = list(np.arange(image_masks.shape[2]))
         else:
-            assert all([isinstance(roi_id, (int, np.integer)) for roi_id in roi_ids]), "'roi_ids' must be int!"
+            assert all(
+                [isinstance(roi_id, (int, np.integer)) for roi_id in roi_ids]
+            ), "'roi_ids' must be int!"
             self._roi_ids = roi_ids
         self._roi_locs = roi_locations
         self._sampling_frequency = sampling_frequency

--- a/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -151,8 +151,6 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         """
         Parameters:
         ----------
-        file_path: str
-            The location of the folder containing the custom file format.
         image_masks: np.ndarray
             Binary image for each of the regions of interest
         raw: np.ndarray
@@ -171,7 +169,7 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             Unique ids of the ROIs if any
         roi_locations: np.ndarray
             x and y location representative of ROI mask
-        samp_freq: float
+        sampling_frequency: float
             Frame rate of the movie
         rejected_list: list
             list of ROI ids that are rejected manually or via automated rejection
@@ -236,9 +234,28 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             self.is_dumpable = False
             self._image_masks = image_masks
             self._roi_response_raw = raw
+            assert self._image_masks.shape[2] == len(
+                self._roi_response_raw), ("Inconsistency between image masks and raw traces. "
+                                          "Image masks must be (px, py, num_rois), "
+                                          "traces must be (num_rois, num_frames)")
             self._roi_response_dff = dff
+            if self._roi_response_dff is not None:
+                assert self._image_masks.shape[2] == len(
+                    self._roi_response_dff), ("Inconsistency between image masks and raw traces. "
+                                              "Image masks must be (px, py, num_rois), "
+                                              "traces must be (num_rois, num_frames)")
             self._roi_response_neuropil = neuropil
+            if self._roi_response_neuropil is not None:
+                assert self._image_masks.shape[2] == len(
+                    self._roi_response_neuropil), ("Inconsistency between image masks and raw traces. "
+                                                   "Image masks must be (px, py, num_rois), "
+                                                   "traces must be (num_rois, num_frames)")
             self._roi_response_deconvolved = deconvolved
+            if self._roi_response_deconvolved is not None:
+                assert self._image_masks.shape[2] == len(
+                    self._roi_response_deconvolved), ("Inconsistency between image masks and raw traces. "
+                                                      "Image masks must be (px, py, num_rois), "
+                                                      "traces must be (num_rois, num_frames)")
             self._kwargs = {
                 "image_masks": image_masks,
                 "signal": raw,
@@ -252,8 +269,9 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         self._image_mean = mean_image
         self._image_correlation = correlation_image
         if roi_ids is None:
-            self._roi_ids = list(np.arange(len(image_masks)))
+            self._roi_ids = list(np.arange(image_masks.shape[2]))
         else:
+            assert all([isinstance(roi_id, (int, np.integer)) for roi_id in roi_ids]), "'roi_ids' must be int!"
             self._roi_ids = roi_ids
         self._roi_locs = roi_locations
         self._sampling_frequency = sampling_frequency

--- a/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -318,10 +318,15 @@ class NwbImagingExtractor(ImagingExtractor):
     def add_devices(imaging, nwbfile, metadata):
         # Devices
         metadata = dict_recursive_update(get_default_nwb_metadata(), metadata)
+        
         # Tests if devices exist in nwbfile, if not create them from metadata
         for dev in metadata["Ophys"]["Device"]:
             if dev["name"] not in nwbfile.devices:
-                nwbfile.create_device(name=dev["name"])
+                if "description" in dev:
+                    descr = dev["description"]
+                else:
+                    descr = None
+                nwbfile.create_device(name=dev["name"], description=descr)
 
         return nwbfile
 

--- a/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -320,7 +320,7 @@ class NwbImagingExtractor(ImagingExtractor):
     def add_devices(imaging, nwbfile, metadata):
         # Devices
         metadata = dict_recursive_update(get_default_nwb_metadata(), metadata)
-        
+
         # Tests if devices exist in nwbfile, if not create them from metadata
         for dev in metadata["Ophys"]["Device"]:
             if dev["name"] not in nwbfile.devices:


### PR DESCRIPTION
- Fixes a bug in instantiating a `NumpySegmentationExtractor` with image_masks. Basically, the `roi_ids` were automatically inferred using the wrong dimension of the masks, resulting in a mismatch between `roi_ids` and the number of masks.
- Propagate properly device description from metadata (@CodyCBakerPhD this second change should be integrated in https://github.com/catalystneuro/nwb-conversion-tools/pull/397)