### PR TITLE
v0.3.2 version bump

### DIFF
--- a/roiextractors/version.py
+++ b/roiextractors/version.py
@@ -1,1 +1,1 @@
-version = "0.3.1"
+version = "0.3.2"


### PR DESCRIPTION
v0.3.2 - Fixes a bug in instantiating a NumpySegmentationExtractor with image_masks. Basically, the roi_ids were automatically inferred using the wrong dimension of the masks, resulting in a mismatch between roi_ids and the number of masks.