### PR TITLE
Warning reduction : remove numpy type warnings.

### DIFF
--- a/roiextractors/extraction_tools.py
+++ b/roiextractors/extraction_tools.py
@@ -23,7 +23,7 @@ PathType = Union[str, Path]
 NumpyArray = Union[np.array, np.memmap]
 DtypeType = Union[str, np.dtype]
 IntType = Union[int, np.integer]
-FloatType = Union[float, np.float]
+FloatType = float
 
 
 def _pixel_mask_extractor(image_mask_, _roi_ids):

--- a/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -93,7 +93,7 @@ class SbxImagingExtractor(ImagingExtractor):
             info["fold_lines"] = 0
             info["fov_repeats"] = 1
 
-        info["frame_rate"] = np.int(
+        info["frame_rate"] = int(
             info["resfreq"]
             / info["config"]["lines"]
             * (2 - info["scanmode"])

--- a/roiextractors/segmentationextractor.py
+++ b/roiextractors/segmentationextractor.py
@@ -236,7 +236,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         samp_freq: float
             Sampling frequency of the recordings in Hz.
         """
-        return np.float(self._sampling_frequency)
+        return float(self._sampling_frequency)
 
     def get_num_rois(self):
         """Returns total number of Regions of Interest in the acquired images.


### PR DESCRIPTION
This PR is the analogous to the one described in `nwb-conversion-tools`:
[Warning reduction : remove numpy type warnings.](https://github.com/catalystneuro/nwb-conversion-tools/pull/459#)