### PR TITLE
Memmap ImagingExtractor classes unification I

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -5,4 +5,5 @@ tqdm>=4.48.2
 lazy_ops>=0.2.0
 dill>=0.3.2
 scipy>=1.5.2
+psutil>=5.8.0
 PyYAML

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -66,7 +66,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging_extractor: ImagingExtractor,
         save_path: PathType = None,
         verbose: bool = False,
-        force_chunk: bool = False,
+        chunk_data: bool = False,
     ):
         """
         Static method to write imaging.
@@ -78,16 +78,16 @@ class MemmapImagingExtractor(ImagingExtractor):
             path to save the native format to.
         verbose: bool
             Displays a progress bar.
-        force_chunk: bool
+        chunk_data: bool
             Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
-        safety_margin = 0.80  # Accept a file smaller than 80 per cent of available memory
+        memory_safety_margin = 0.80  # Accept a file smaller than 80 per cent of available memory
         file_size_in_bytes = Path(imaging.file_path).stat().st_size
         available_memory_in_bytes = psutil.virtual_memory().available
 
-        memory_limit = available_memory_in_bytes * safety_margin
-        if file_size_in_bytes < memory_limit and not force_chunk:
+        memory_limit = available_memory_in_bytes * memory_safety_margin
+        if file_size_in_bytes < memory_limit and not chunk_data:
             video_data_to_save = imaging.get_frames()
             memmap_shape = video_data_to_save.shape
             video_memmap = np.memmap(
@@ -101,7 +101,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             video_memmap.flush()
 
         else:
-            chunk_size_in_bytes = int(available_memory_in_bytes * safety_margin)
+            chunk_size_in_bytes = int(available_memory_in_bytes * memory_safety_margin)
             dtype = imaging.get_dtype()
             type_size = np.dtype(dtype).itemsize
 

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -22,10 +22,8 @@ class MemmapImagingExtractor(ImagingExtractor):
 
     def __init__(
         self,
-        imaging_extractor: ImagingExtractor,
-        save_path: PathType = None,
-        verbose: bool = False,
     ):
+        super().__init__()
 
         pass
 
@@ -71,36 +69,20 @@ class MemmapImagingExtractor(ImagingExtractor):
         Parameters
         ----------
         imaging: ImagingExtractor object
-            The EXTRACT segmentation object from which an EXTRACT native format
-            file has to be generated.
         save_path: str
             path to save the native format.
         overwrite: bool
             If True and save_path is existing, it is overwritten
         """
         imaging = imaging_extractor
-        video_to_save = np.memmap(
+        video_data_to_save = imaging.get_frames()[:]
+        memmap_shape = video_data_to_save.shape
+        video_memmap = np.memmap(
             save_path,
-            shape=(
-                imaging.get_num_frames(),
-                imaging.get_num_channels(),
-                imaging.get_image_size()[0],
-                imaging.get_image_size()[1],
-            ),
+            shape=memmap_shape,
             dtype=imaging.get_dtype(),
             mode="w+",
         )
 
-        if verbose:
-            for ch in range(imaging.get_num_channels()):
-                print(f"Saving channel {ch}")
-                for i in tqdm(range(imaging.get_num_frames())):
-                    plane = imaging.get_frames(i, channel=ch)
-                    video_to_save[ch, i] = plane
-        else:
-            for ch in range(imaging.get_num_channels()):
-                for i in range(imaging.get_num_frames()):
-                    plane = imaging.get_frames(i, channel=ch)
-                    video_to_save[ch, i] = plane
-
-        video_to_save.flush()
+        video_memmap[:] = video_data_to_save
+        video_memmap.flush()

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -72,9 +72,11 @@ class MemmapImagingExtractor(ImagingExtractor):
         ----------
         imaging: ImagingExtractor object
         save_path: str
-            path to save the native format.
-        overwrite: bool
-            If True and save_path is existing, it is overwritten
+            path to save the native format to.
+        verbose: bool
+            Displays a progress bar.
+        force_chunk: bool
+            Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
         safety_margin = 0.80  # 80 per cent

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -113,7 +113,7 @@ class MemmapImagingExtractor(ImagingExtractor):
 
             iterator = range(0, num_frames, frames_per_chunk)
             if verbose:
-                iterator = tqdm(iterator, ascii=True, desc="Writing to .tiff file")
+                iterator = tqdm(iterator, ascii=True, desc="Writing to .dat file")
 
             for frame in iterator:
                 end_frame = min(frame + frames_per_chunk, num_frames)

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -66,7 +66,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging_extractor: ImagingExtractor,
         save_path: PathType = None,
         verbose: bool = False,
-        chunk_data: bool = False,
+        buffer_data: bool = False,
     ):
         """
         Static method to write imaging.
@@ -78,7 +78,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             path to save the native format to.
         verbose: bool
             Displays a progress bar.
-        chunk_data: bool
+        buffer_data: bool
             Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
@@ -87,7 +87,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         available_memory_in_bytes = psutil.virtual_memory().available
 
         memory_limit = available_memory_in_bytes * memory_safety_margin
-        if file_size_in_bytes < memory_limit and not chunk_data:
+        if file_size_in_bytes < memory_limit and not buffer_data:
             video_data_to_save = imaging.get_frames()
             memmap_shape = video_data_to_save.shape
             video_memmap = np.memmap(

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -66,7 +66,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging_extractor: ImagingExtractor,
         save_path: PathType,
         verbose: bool = False,
-        buffer_gb: int = 0,
+        buffer_gb: float = 0,
     ):
         """
         Static method to write imaging.
@@ -84,9 +84,9 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging = imaging_extractor
         file_size_in_bytes = Path(imaging.file_path).stat().st_size
         available_memory_in_bytes = psutil.virtual_memory().available
-        buffer_size_in_bytes = buffer_gb * 10**9
+        buffer_size_in_bytes = buffer_gb * 1e9
         if available_memory_in_bytes < buffer_size_in_bytes:
-            raise f"Not enough memory available memory {available_memory_in_bytes* 10**9} for buffer size {buffer_gb}"
+            raise f"Not enough memory available memory {available_memory_in_bytes* 1e9} for buffer size {buffer_gb}"
 
         num_frames = imaging.get_num_frames()
         memmap_shape = imaging.video_structure.build_video_shape(n_frames=num_frames)

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -20,6 +20,9 @@ class MemmapImagingExtractor(ImagingExtractor):
     def __init__(
         self,
     ):
+        """
+        Abstract class for memmapable imaging extractors.
+        """
         super().__init__()
 
         pass
@@ -70,7 +73,7 @@ class MemmapImagingExtractor(ImagingExtractor):
 
         Parameters
         ----------
-        imaging: ImagingExtractor object
+        imaging: An ImagingExtractor object that inherited from MemmapImagingExtractor
         save_path: str
             path to save the native format to.
         verbose: bool
@@ -79,7 +82,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
-        safety_margin = 0.80  # 80 per cent
+        safety_margin = 0.80  # Accept a file smaller than 80 per cent of available memory
         file_size_in_bytes = Path(imaging.file_path).stat().st_size
         available_memory_in_bytes = psutil.virtual_memory().available
 
@@ -106,7 +109,6 @@ class MemmapImagingExtractor(ImagingExtractor):
             pixels_per_frame = n_channels * np.product(imaging.get_image_size())
             bytes_per_frame = type_size * pixels_per_frame
             frames_per_chunk = chunk_size_in_bytes // bytes_per_frame
-            # number_of_chunks = file_size_in_bytes / chunk_size_in_bytes
 
             num_frames = imaging.get_num_frames()
             memmap_shape = imaging.video_structure.build_video_shape(n_frames=num_frames)
@@ -129,7 +131,7 @@ class MemmapImagingExtractor(ImagingExtractor):
                     mode="w+",
                 )
 
-                # Write to map
+                # Fit the video chunk in the memmap array
                 indices = np.arange(start=frame, stop=end_frame)
                 axis_to_expand = (
                     imaging.video_structure.rows_axis,

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -100,6 +100,10 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
 
         return frames
 
+    def get_video(self, start_frame: int = None, end_frame: int = None) -> np.array:
+        frame_idxs = range(start_frame, end_frame)
+        return self.get_frames(frame_idxs=frame_idxs)
+
     def get_image_size(self):
         return (self._rows, self._columns)
 

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -7,13 +7,8 @@ from tqdm import tqdm
 
 from ...imagingextractor import ImagingExtractor
 from typing import Tuple, Dict
-from roiextractors.extraction_tools import read_numpy_memmap_video, VideoStructure
+from roiextractors.extraction_tools import read_numpy_memmap_video, VideoStructure, DtypeType, PathType
 from .memmapextractors import MemmapImagingExtractor
-
-from ...extraction_tools import (
-    PathType,
-    DtypeType,
-)
 
 
 class NumpyMemmapImagingExtractor(MemmapImagingExtractor):

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from ...imagingextractor import ImagingExtractor
 from typing import Tuple, Dict
 from roiextractors.extraction_tools import read_numpy_memmap_video, VideoStructure
+from .memmapextractors import MemmapImagingExtractor
 
 from ...extraction_tools import (
     PathType,
@@ -15,7 +16,7 @@ from ...extraction_tools import (
 )
 
 
-class NumpyMemmapImagingExtractor(ImagingExtractor):
+class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
 
     extractor_name = "NumpyMemmapImagingExtractor"
 
@@ -130,29 +131,3 @@ class NumpyMemmapImagingExtractor(ImagingExtractor):
 
     def get_dtype(self) -> DtypeType:
         return self.dtype
-
-    @staticmethod
-    def write_imaging(imaging_extractor: ImagingExtractor, save_path: PathType = None, verbose: bool = False):
-        """
-        Static method to write imaging.
-
-        Parameters
-        ----------
-        imaging: ImagingExtractor object
-        save_path: str
-            path to save the native format.
-        overwrite: bool
-            If True and save_path is existing, it is overwritten
-        """
-        imaging = imaging_extractor
-        video_data_to_save = imaging.get_frames()[:]
-        memmap_shape = video_data_to_save.shape
-        video_memmap = np.memmap(
-            save_path,
-            shape=memmap_shape,
-            dtype=imaging.get_dtype(),
-            mode="w+",
-        )
-
-        video_memmap[:] = video_data_to_save
-        video_memmap.flush()

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,18 +34,23 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    for dtype, num_channels, rows, columns in product(dtype_list, num_channels_list, sizes_list, sizes_list):
+    chunking_condition = [True, False]
+    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
+        dtype, num_channels, rows, columns, force_chunking = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            case_name=f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}",
+            force_chunking=force_chunking,
+            case_name=(
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={force_chunking}"
+            ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, force_chunking, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -79,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path)
+        extractor.write_imaging(extractor, write_path, force_chunk=force_chunking)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,23 +34,23 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    chunking_condition = [True, False]
-    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
-        dtype, num_channels, rows, columns, chunk_data = parameters
+    ber_data_condition_condition = [True, False]
+    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, ber_data_condition_condition):
+        dtype, num_channels, rows, columns, buffer_data = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            chunk_data=chunk_data,
+            buffer_data=buffer_data,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={chunk_data}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_data={buffer_data}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, chunk_data, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_data, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, chunk_data=chunk_data)
+        extractor.write_imaging(extractor, write_path, buffer_data=buffer_data)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,23 +34,23 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    ber_data_condition_condition = [True, False]
-    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, ber_data_condition_condition):
-        dtype, num_channels, rows, columns, buffer_data = parameters
+    buffer_gb_list = [0.0001, 1]
+    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, buffer_gb_list):
+        dtype, num_channels, rows, columns, buffer_gb = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            buffer_data=buffer_data,
+            buffer_gb=buffer_gb,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_data={buffer_data}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_gb={buffer_gb}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_data, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_gb, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, buffer_data=buffer_data)
+        extractor.write_imaging(extractor, write_path, buffer_gb=buffer_gb)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -36,21 +36,21 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     sizes_list = [10, 25]
     chunking_condition = [True, False]
     for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
-        dtype, num_channels, rows, columns, force_chunk = parameters
+        dtype, num_channels, rows, columns, chunk_data = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            force_chunk=force_chunk,
+            chunk_data=chunk_data,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={force_chunk}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={chunk_data}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, force_chunk, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, chunk_data, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, force_chunk=force_chunk)
+        extractor.write_imaging(extractor, write_path, chunk_data=chunk_data)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,23 +34,25 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    buffer_gb_list = [0.0001, 1]
+    buffer_gb_list = [None, 0.1]
     for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, buffer_gb_list):
-        dtype, num_channels, rows, columns, buffer_gb = parameters
+        dtype, num_channels, rows, columns, buffer_size_in_gb = parameters
+        case_name = (
+            f"dtype={dtype}, num_channels={num_channels}, rows={rows},"
+            f"columns={columns}, buffer_size_in_gb={buffer_size_in_gb}"
+        )
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            buffer_gb=buffer_gb,
-            case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_gb={buffer_gb}"
-            ),
+            buffer_size_in_gb=buffer_size_in_gb,
+            case_name=case_name,
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_gb, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_size_in_gb, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +86,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, buffer_gb=buffer_gb)
+        extractor.write_imaging(extractor, write_path, buffer_size_in_gb=buffer_size_in_gb)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -36,21 +36,21 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     sizes_list = [10, 25]
     chunking_condition = [True, False]
     for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
-        dtype, num_channels, rows, columns, force_chunking = parameters
+        dtype, num_channels, rows, columns, force_chunk = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            force_chunking=force_chunking,
+            force_chunk=force_chunk,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={force_chunking}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={force_chunk}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, force_chunking, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, force_chunk, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, force_chunk=force_chunking)
+        extractor.write_imaging(extractor, write_path, force_chunk=force_chunk)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,


### PR DESCRIPTION
This just moves the `write_imaging` method from `NumpyMemmapImagingExtractor` to `MemmapImagingExtractor` Subsequent PRs should also migrate the reading functionality to the `MemmapImagingExtractor` and unify this with the `Hdf5ImagingExtractor`.