### PR TITLE
Memmap extractor unification II

### DIFF
--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import scipy
-from spikeextractors.extraction_tools import cast_start_end_frame
 from tqdm import tqdm
+
+import lazy_ops
+from spikeextractors.extraction_tools import cast_start_end_frame
 
 try:
     import h5py
@@ -23,6 +25,13 @@ try:
     HAVE_Scipy = True
 except ImportError:
     HAVE_Scipy = False
+
+try:
+    import zarr
+
+    HAVE_ZARR = True
+except ImportError:
+    HAVE_ZARR = False
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]
@@ -52,15 +61,15 @@ class VideoStructure:
     where the video is to have the following shape (n_frames, rows, columns, n_channels) you
     could define the class this way:
 
-    from roiextractors.extraction_tools import VideoStructure
-    rows = 10
-    columns = 5
-    num_channels = 1
-    frame_axis = 0
-    rows_axis = 1
-    columns_axis = 2
-    num_channels_axis = 3
-    video_structure = VideoStructure(
+    >>> from roiextractors.extraction_tools import VideoStructure
+    >>> rows = 10
+    >>> columns = 5
+    >>> num_channels = 1
+    >>> frame_axis = 0
+    >>> rows_axis = 1
+    >>> columns_axis = 2
+    >>> num_channels_axis = 3
+    >>> video_structure = VideoStructure(
         rows=rows,
         columns=columns,
         num_channels=num_channels,
@@ -119,15 +128,33 @@ class VideoStructure:
 
         return tuple(video_shape)
 
-    def transform_video_to_canonical_form(self, video: np.array) -> np.array:
-        canonical_frame_axis = 0
-        canonical_rows_axis = 1
-        canonical_columns_axis = 2
-        canonical_num_channels_axis = 3
+    def transform_video_to_canonical_form(self, video: np.ndarray) -> np.ndarray:
+        """Transform a video with the structure in this class to the canonical internal format of
+        roiextractors (frames, rows, columns, num_channels)
 
-        # To-do Implement the mapping
-        re_mapped_video = None
-        assert "Not Implemented yet"
+        The function supports either
+        Parameters
+        ----------
+        video : np.ndarray
+            The video to be transformed
+        Returns
+        -------
+        np.ndarray
+            The reshaped video
+
+        Raises
+        ------
+        KeyError
+
+        """
+        canonical_shape = (self.frame_axis, self.rows_axis, self.columns_axis, self.num_channels_axis)
+        if isinstance(video, (h5py.Dataset, zarr.core.Array)):
+            re_mapped_video = lazy_ops.DatasetView(video).lazy_transpose(canonical_shape)
+        elif isinstance(video, np.ndarray):
+            re_mapped_video = video.transpose(canonical_shape)
+        else:
+            raise KeyError(f"Function not implemented for specific format {type(video)}")
+
         return re_mapped_video
 
 

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -26,6 +26,13 @@ try:
 except ImportError:
     HAVE_Scipy = False
 
+try:
+    import zarr
+
+    HAVE_ZARR = True
+except ImportError:
+    HAVE_ZARR = False
+
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -26,12 +26,6 @@ try:
 except ImportError:
     HAVE_Scipy = False
 
-try:
-    import zarr
-
-    HAVE_ZARR = True
-except ImportError:
-    HAVE_ZARR = False
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -66,7 +66,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging_extractor: ImagingExtractor,
         save_path: PathType = None,
         verbose: bool = False,
-        force_chunk: bool = False,
+        chunk_data: bool = False,
     ):
         """
         Static method to write imaging.
@@ -78,16 +78,16 @@ class MemmapImagingExtractor(ImagingExtractor):
             path to save the native format to.
         verbose: bool
             Displays a progress bar.
-        force_chunk: bool
+        chunk_data: bool
             Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
-        safety_margin = 0.80  # Accept a file smaller than 80 per cent of available memory
+        memory_safety_margin = 0.80  # Accept a file smaller than 80 per cent of available memory
         file_size_in_bytes = Path(imaging.file_path).stat().st_size
         available_memory_in_bytes = psutil.virtual_memory().available
 
-        memory_limit = available_memory_in_bytes * safety_margin
-        if file_size_in_bytes < memory_limit and not force_chunk:
+        memory_limit = available_memory_in_bytes * memory_safety_margin
+        if file_size_in_bytes < memory_limit and not chunk_data:
             video_data_to_save = imaging.get_frames()
             memmap_shape = video_data_to_save.shape
             video_memmap = np.memmap(
@@ -101,7 +101,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             video_memmap.flush()
 
         else:
-            chunk_size_in_bytes = int(available_memory_in_bytes * safety_margin)
+            chunk_size_in_bytes = int(available_memory_in_bytes * memory_safety_margin)
             dtype = imaging.get_dtype()
             type_size = np.dtype(dtype).itemsize
 

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -66,7 +66,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         imaging_extractor: ImagingExtractor,
         save_path: PathType = None,
         verbose: bool = False,
-        chunk_data: bool = False,
+        buffer_data: bool = False,
     ):
         """
         Static method to write imaging.
@@ -78,7 +78,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             path to save the native format to.
         verbose: bool
             Displays a progress bar.
-        chunk_data: bool
+        buffer_data: bool
             Forces chunk to occur even if memmory is available
         """
         imaging = imaging_extractor
@@ -87,7 +87,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         available_memory_in_bytes = psutil.virtual_memory().available
 
         memory_limit = available_memory_in_bytes * memory_safety_margin
-        if file_size_in_bytes < memory_limit and not chunk_data:
+        if file_size_in_bytes < memory_limit and not buffer_data:
             video_data_to_save = imaging.get_frames()
             memmap_shape = video_data_to_save.shape
             video_memmap = np.memmap(

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -66,7 +66,6 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         """
 
         self.installed = True
-        super().__init__()
 
         self.file_path = Path(file_path)
         self.video_structure = video_structure
@@ -78,55 +77,7 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         self._video = read_numpy_memmap_video(
             file_path=file_path, video_structure=video_structure, dtype=dtype, offset=offset
         )
+        self._video = video_structure.transform_video_to_canonical_form(self._video)
+        self._num_frames, self._rows, self._columns, self._num_channels = self._video.shape
 
-        # Get the image structure as attributes
-        self._rows = self.video_structure.rows
-        self._columns = self.video_structure.columns
-        self._num_channels = self.video_structure.num_channels
-
-        self.frame_axis = self.video_structure.frame_axis
-        self._num_frames = self._video.shape[self.frame_axis]
-
-    def get_frames(self, frame_idxs=None):
-        if frame_idxs is None:
-            frame_idxs = [frame for frame in range(self.get_num_frames())]
-
-        frames = self._video.take(indices=frame_idxs, axis=self.frame_axis)
-
-        return frames
-
-    def get_video(self, start_frame: int = None, end_frame: int = None) -> np.array:
-        frame_idxs = range(start_frame, end_frame)
-        return self.get_frames(frame_idxs=frame_idxs)
-
-    def get_image_size(self):
-        return (self._rows, self._columns)
-
-    def get_num_frames(self):
-        return self._num_frames
-
-    def get_sampling_frequency(self):
-        return self._sampling_frequency
-
-    def get_channel_names(self):
-        """List of  channels in the recoding.
-
-        Returns
-        -------
-        channel_names: list
-            List of strings of channel names
-        """
-        pass
-
-    def get_num_channels(self):
-        """Total number of active channels in the recording
-
-        Returns
-        -------
-        no_of_channels: int
-            integer count of number of channels
-        """
-        return self._num_channels
-
-    def get_dtype(self) -> DtypeType:
-        return self.dtype
+        super().__init__(video=self._video)

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -7,13 +7,8 @@ from tqdm import tqdm
 
 from ...imagingextractor import ImagingExtractor
 from typing import Tuple, Dict
-from roiextractors.extraction_tools import read_numpy_memmap_video, VideoStructure
+from roiextractors.extraction_tools import read_numpy_memmap_video, VideoStructure, DtypeType, PathType
 from .memmapextractors import MemmapImagingExtractor
-
-from ...extraction_tools import (
-    PathType,
-    DtypeType,
-)
 
 
 class NumpyMemmapImagingExtractor(MemmapImagingExtractor):

--- a/tests/test_internals/test_extraction_tools.py
+++ b/tests/test_internals/test_extraction_tools.py
@@ -174,7 +174,7 @@ class TestReadNumpyMemmapVideo(unittest.TestCase):
 
         # Build a random video
         memmap_shape = video_structure.build_video_shape(self.num_frames)
-        random_video = np.random.randint(low=1, size=memmap_shape).astype(dtype)
+        random_video = np.random.randint(low=0, high=256, size=memmap_shape).astype(dtype)
 
         # Save it to memory
         file_path = self.write_directory / f"video_{case_name}.dat"
@@ -189,6 +189,10 @@ class TestReadNumpyMemmapVideo(unittest.TestCase):
         )
         # Compare the extracted video
         np.testing.assert_array_almost_equal(random_video, memmap_video)
+
+        # Test canonical form
+        canonical_video = video_structure.transform_video_to_canonical_form(memmap_video)
+        assert canonical_video.shape == (self.num_frames, rows, columns, num_channels)
 
 
 if __name__ == "__main__":

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,23 +34,23 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    chunking_condition = [True, False]
-    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
-        dtype, num_channels, rows, columns, chunk_data = parameters
+    ber_data_condition_condition = [True, False]
+    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, ber_data_condition_condition):
+        dtype, num_channels, rows, columns, buffer_data = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            chunk_data=chunk_data,
+            buffer_data=buffer_data,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={chunk_data}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_data={buffer_data}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, chunk_data, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_data, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, chunk_data=chunk_data)
+        extractor.write_imaging(extractor, write_path, buffer_data=buffer_data)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -34,23 +34,23 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     dtype_list = ["uint16", "float", "int"]
     num_channels_list = [1, 3]
     sizes_list = [10, 25]
-    ber_data_condition_condition = [True, False]
-    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, ber_data_condition_condition):
-        dtype, num_channels, rows, columns, buffer_data = parameters
+    buffer_gb_list = [0.0001, 1]
+    for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, buffer_gb_list):
+        dtype, num_channels, rows, columns, buffer_gb = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            buffer_data=buffer_data,
+            buffer_gb=buffer_gb,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_data={buffer_data}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, buffer_gb={buffer_gb}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_data, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, buffer_gb, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, buffer_data=buffer_data)
+        extractor.write_imaging(extractor, write_path, buffer_gb=buffer_gb)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -36,21 +36,21 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
     sizes_list = [10, 25]
     chunking_condition = [True, False]
     for parameters in product(dtype_list, num_channels_list, sizes_list, sizes_list, chunking_condition):
-        dtype, num_channels, rows, columns, force_chunk = parameters
+        dtype, num_channels, rows, columns, chunk_data = parameters
         param_case = param(
             dtype=dtype,
             num_channels=num_channels,
             rows=rows,
             columns=columns,
-            force_chunk=force_chunk,
+            chunk_data=chunk_data,
             case_name=(
-                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={force_chunk}"
+                f"dtype={dtype}, num_channels={num_channels}, rows={rows}, columns={columns}, chunking={chunk_data}"
             ),
         )
         parameterized_list.append(param_case)
 
     @parameterized.expand(input=parameterized_list, name_func=custom_name_func)
-    def test_roundtrip(self, dtype, num_channels, rows, columns, force_chunk, case_name=""):
+    def test_roundtrip(self, dtype, num_channels, rows, columns, chunk_data, case_name=""):
 
         permutation = self.rng.choice([0, 1, 2, 3], size=4, replace=False)
         rows_axis, columns_axis, num_channels_axis, frame_axis = permutation
@@ -84,7 +84,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         # Use the write method and do a round-trip
         write_path = self.write_directory / f"video_output_{case_name}.dat"
-        extractor.write_imaging(extractor, write_path, force_chunk=force_chunk)
+        extractor.write_imaging(extractor, write_path, chunk_data=chunk_data)
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -82,9 +82,21 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
             file_path=file_path, video_structure=video_structure, sampling_frequency=1, dtype=dtype, offset=self.offset
         )
 
-        # Use the write method and do a round-trip
+        # Use the write method
         write_path = self.write_directory / f"video_output_{case_name}.dat"
         extractor.write_imaging(extractor, write_path, buffer_gb=buffer_gb)
+
+        # Read again for a round-trip, note that the data is stored in canonical form.
+        video_structure = VideoStructure(
+            rows=rows,
+            columns=columns,
+            num_channels=num_channels,
+            rows_axis=1,
+            columns_axis=2,
+            num_channels_axis=3,
+            frame_axis=0,
+        )
+
         roundtrip_extractor = NumpyMemmapImagingExtractor(
             file_path=write_path,
             video_structure=video_structure,


### PR DESCRIPTION
This PR is a follow up #122  and has it as its base. 
It implements the following things:

1) The `VideoStructure` data class now implements a method `transform_video_to_canonical_form` that converts a video with a the given structure to the canonical form `(num_frames, rows, columns, num_channels)`. A condition was added into the `test_extraction_tools` that test this functionality.

2) `NumpyMemmapImagingExtractor` now transforms its video to the canonical form and the methods (including `write_imaging` in `MemmapImagingExtractor`) are refactored to account for this.

3) All the methods of `NumpyMemmapImagingExtractor` are moved to the abstract `MemmapImagingExtractor` class.