### PR TITLE
Function `get_image_size` should return tuples

### DIFF
--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -9,6 +9,7 @@ from ...extraction_tools import (
     write_to_h5_dataset_format,
 )
 from ...imagingextractor import ImagingExtractor
+from typing import Tuple
 
 try:
     import h5py
@@ -107,7 +108,7 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             return self._video[channel, sorted_idxs][:, argsorted_idxs]
             # return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
 
-    def get_image_size(self):
+    def get_image_size(self) -> Tuple[int, int]:
         return (self._size_x, self._size_y)
 
     def get_num_frames(self):

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -108,7 +108,7 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             # return lazy_ops.DatasetView(self._video).lazy_slice[channel, sorted_idxs].lazy_slice[:, argsorted_idxs]
 
     def get_image_size(self):
-        return [self._size_x, self._size_y]
+        return (self._size_x, self._size_y)
 
     def get_num_frames(self):
         return self._num_frames

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -7,6 +7,8 @@ from ...extraction_tools import PathType, ArrayType
 from ...extraction_tools import check_keys
 from ...imagingextractor import ImagingExtractor
 
+from typing import Tuple
+
 try:
     import scipy.io as spio
 
@@ -130,7 +132,7 @@ class SbxImagingExtractor(ImagingExtractor):
         frame_out = np.stack(frames_list, axis=2).T.squeeze()
         return np.iinfo("uint16").max - frame_out
 
-    def get_image_size(self) -> ArrayType:
+    def get_image_size(self) -> Tuple[int, int]:
         return tuple(self._info["sz"])
 
     def get_num_frames(self) -> int:

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -131,7 +131,7 @@ class SbxImagingExtractor(ImagingExtractor):
         return np.iinfo("uint16").max - frame_out
 
     def get_image_size(self) -> ArrayType:
-        return self._info["sz"]
+        return tuple(self._info["sz"])
 
     def get_num_frames(self) -> int:
         return (self._info["max_idx"] + 1) // self._info["nplanes"]

--- a/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
@@ -11,6 +11,8 @@ from ...extraction_tools import (
     FloatType,
     ArrayType,
 )
+
+from typing import Tuple
 from ...imagingextractor import ImagingExtractor
 
 try:
@@ -80,7 +82,7 @@ class TiffImagingExtractor(ImagingExtractor):
     def get_frames(self, frame_idxs, channel=0):
         return self._video[channel, frame_idxs]
 
-    def get_image_size(self):
+    def get_image_size(self) -> Tuple[int, int]:
         return (self._size_x, self._size_y)
 
     def get_num_frames(self):

--- a/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
@@ -81,7 +81,7 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._video[channel, frame_idxs]
 
     def get_image_size(self):
-        return [self._size_x, self._size_y]
+        return (self._size_x, self._size_y)
 
     def get_num_frames(self):
         return self._num_frames

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -14,6 +14,7 @@ from .extraction_tools import (
     FloatType,
     check_get_videos_args,
 )
+from typing import Tuple
 
 
 class ImagingExtractor(ABC, BaseExtractor):
@@ -31,7 +32,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         pass
 
     @abstractmethod
-    def get_image_size(self) -> ArrayType:
+    def get_image_size(self) -> Tuple[int, int]:
         pass
 
     @abstractmethod


### PR DESCRIPTION
The `get_image_size` function of the `SbxImagingExtractor` was returning an array which was causing problems in `nwb-conversion-tools`. 

Moreover, I think that all the `get_image_size` functions should return a tuple to mark the image size properly as an immutable. This PR fixes the problem and makes the output for all the imaging extractors a tuple. 