### PR TITLE
Add MultiImagingExtractor

### DIFF
--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -56,9 +56,10 @@ class MultiImagingExtractor(ImagingExtractor):
     @check_get_frames_args
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> NumpyArray:
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")
+        relative_frame_indices = frame_idxs - np.array(self._start_frames)[extractor_indices]
         # Match frame_idxs to imaging extractors
         extractors_dict = defaultdict(list)
-        for extractor_index, frame_index in zip(extractor_indices, frame_idxs):
+        for extractor_index, frame_index in zip(extractor_indices, relative_frame_indices):
             extractors_dict[extractor_index].append(frame_index)
 
         frames_to_concatenate = []
@@ -76,10 +77,8 @@ class MultiImagingExtractor(ImagingExtractor):
         return frames
 
     def _get_frames_from_an_imaging_extractor(self, extractor_index: int, frame_idxs: ArrayType) -> NumpyArray:
-        relative_frame_indices = (np.array(frame_idxs) - self._start_frames[extractor_index]).astype(int)
         imaging_extractor = self._imaging_extractors[extractor_index]
-
-        frames = imaging_extractor.get_frames(frame_idxs=relative_frame_indices)
+        frames = imaging_extractor.get_frames(frame_idxs=frame_idxs)
         return frames
 
     def get_image_size(self) -> Tuple:

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -56,10 +56,7 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
             get_channel_names="The name of the channels",
         )
         for method, property_message in properties_to_check.items():
-            values = [
-                getattr(extractor, method)() if hasattr(extractor, method) else None
-                for extractor in self._imaging_extractors
-            ]
+            values = [getattr(extractor, method, None) for extractor in self._imaging_extractors]
             unique_values = list(set(values))
             assert len(unique_values) == 1, f"{property_message} is not consistent over the files (found {unique_values})."
 

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -62,7 +62,7 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
                 for extractor in self._imaging_extractors
             ]
             unique_values = list(set(values))
-            assert len(unique_values) == 1, f"{property_desc} is not consistent over the files {unique_values}"
+            assert len(unique_values) == 1, f"{property_desc} is not consistent over the files (found {unique_values})."
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -33,11 +33,17 @@ class MultiImagingExtractor(ImagingExtractor):
 
         self._start_frames, self._end_frames = [], []
         num_frames = 0
+        times = []
         for imaging_extractor in self._imaging_extractors:
             self._start_frames.append(num_frames)
             num_frames = num_frames + imaging_extractor.get_num_frames()
             self._end_frames.append(num_frames)
+            if getattr(imaging_extractor, "_times") is not None:
+                times.extend(imaging_extractor._times)
         self._num_frames = num_frames
+
+        if times:
+            self.set_times(times=times)
 
     def _check_consistency_between_imaging_extractors(self):
         properties_to_check = dict(

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -62,9 +62,7 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
                 for extractor in self._imaging_extractors
             ]
             unique_values = list(set(values))
-            assert (
-                len(unique_values) == 1
-            ), f"{property_desc} is not consistent over the files {unique_values}"
+            assert len(unique_values) == 1, f"{property_desc} is not consistent over the files {unique_values}"
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -1,0 +1,87 @@
+from abc import ABC
+from array import ArrayType
+from typing import Tuple
+
+from .extraction_tools import NumpyArray
+from .imagingextractor import ImagingExtractor
+
+
+class MultiImagingExtractor(ImagingExtractor, ABC):
+    """
+    This class is used to combine multiple ImagingExtractor objects by frame.
+    """
+
+    extractor_name = "MultiImagingExtractor"
+    installed = True
+    installation_mesg = ""
+
+    def __init__(self, imaging_extractors: list):
+        """
+        Parameters
+        ----------
+        imaging_extractors: list of ImagingExtractor
+            list of imaging extractor objects
+        """
+        super().__init__()
+        assert isinstance(
+            imaging_extractors, list
+        ), "Enter a list of imaging extractor objects as argument"
+        assert all(isinstance(IX, ImagingExtractor) for IX in imaging_extractors)
+        self._imaging_extractors = imaging_extractors
+
+        # Num channels and sampling frequency based off the initial extractor
+        self._first_imaging_extractor = self._imaging_extractors[0]
+        self._num_channels = self._first_imaging_extractor.get_num_channels()
+        self._channel_names = self._first_imaging_extractor.get_channel_names()
+        self._sampling_frequency = (
+            self._first_imaging_extractor.get_sampling_frequency()
+        )
+        self._image_size = self._first_imaging_extractor.get_image_size()
+
+        self._start_frames, self._end_frames = [], []
+        num_frames = 0.0
+        for extractor_index, imaging_extractor in enumerate(self._imaging_extractors):
+            self._start_frames.append(num_frames)
+            num_frames = num_frames + imaging_extractor.get_num_frames()
+            self._end_frames.append(num_frames)
+
+            # Check consistency between extractors
+            sampling_frequency = imaging_extractor.get_sampling_frequency()
+            assert (
+                self._sampling_frequency == sampling_frequency
+            ), f"Inconsistent sampling frequency ({sampling_frequency}) for {imaging_extractor.file_path}"
+            image_size = imaging_extractor.get_image_size()
+            assert (
+                self._image_size == image_size
+            ), f"Inconsistent image size ({image_size}) for {imaging_extractor.file_path}"
+
+        self._num_frames = int(num_frames)
+
+    def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
+        extractor_index = self._get_imaging_extractor_index(frame_idxs[0])
+        rel_frame_index = frame_idxs[0] - int(self._start_frames[extractor_index])
+        imaging_extractor = self._imaging_extractors[extractor_index]
+
+        return imaging_extractor.get_frames(frame_idxs=[rel_frame_index])
+
+    def _get_imaging_extractor_index(self, frame_index: int):
+        for ind, (start, end) in enumerate(zip(self._start_frames, self._end_frames)):
+            if start <= frame_index < end:
+                return ind
+
+        return len(self._start_frames) - 1
+
+    def get_image_size(self) -> Tuple:
+        return self._image_size
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_sampling_frequency(self) -> float:
+        return self._sampling_frequency
+
+    def get_channel_names(self) -> list:
+        return self._channel_names
+
+    def get_num_channels(self) -> int:
+        return self._num_channels

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from array import ArrayType
-from typing import Tuple
+from typing import Tuple, List
 
 import numpy as np
 
@@ -17,7 +17,7 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
     installed = True
     installation_mesg = ""
 
-    def __init__(self, imaging_extractors: list):
+    def __init__(self, imaging_extractors: List[ImagingExtractor]):
         """
         Parameters
         ----------

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -70,12 +70,8 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
         frames = np.concatenate(frames_to_concatenate, axis=0)
         return frames
 
-    def _get_frames_from_an_imaging_extractor(
-        self, extractor_index: int, frame_idxs: ArrayType
-    ):
-        relative_frame_indices = (
-            np.array(frame_idxs) - self._start_frames[extractor_index]
-        ).astype(int)
+    def _get_frames_from_an_imaging_extractor(self, extractor_index: int, frame_idxs: ArrayType):
+        relative_frame_indices = (np.array(frame_idxs) - self._start_frames[extractor_index]).astype(int)
         imaging_extractor = self._imaging_extractors[extractor_index]
 
         frames = imaging_extractor.get_frames(frame_idxs=relative_frame_indices)

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -53,8 +53,8 @@ class MultiImagingExtractor(ImagingExtractor):
                 len(unique_values) == 1
             ), f"{property_message} is not consistent over the files (found {unique_values})."
 
-    def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
-        assert max(frame_idxs) < self._num_frames, "'frame_idxs' range beyond number of available frames!"
+    @check_get_frames_args
+    def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> NumpyArray:
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")
         # Match frame_idxs to imaging extractors
         extractors_dict = defaultdict(list)

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -2,6 +2,8 @@ from abc import ABC
 from array import ArrayType
 from typing import Tuple
 
+import numpy as np
+
 from .extraction_tools import NumpyArray
 from .imagingextractor import ImagingExtractor
 
@@ -40,7 +42,7 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
 
         self._start_frames, self._end_frames = [], []
         num_frames = 0.0
-        for extractor_index, imaging_extractor in enumerate(self._imaging_extractors):
+        for imaging_extractor in self._imaging_extractors:
             self._start_frames.append(num_frames)
             num_frames = num_frames + imaging_extractor.get_num_frames()
             self._end_frames.append(num_frames)

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -50,19 +50,18 @@ class MultiImagingExtractor(ImagingExtractor, ABC):
 
     def _check_consistency_between_imaging_extractors(self):
         properties_to_check = dict(
-            get_num_frames="The number of frames",
             get_sampling_frequency="The sampling frequency",
             get_image_size="The size of a frame",
             get_num_channels="The number of channels",
             get_channel_names="The name of the channels",
         )
-        for method, property_desc in properties_to_check.items():
+        for method, property_message in properties_to_check.items():
             values = [
                 getattr(extractor, method)() if hasattr(extractor, method) else None
                 for extractor in self._imaging_extractors
             ]
             unique_values = list(set(values))
-            assert len(unique_values) == 1, f"{property_desc} is not consistent over the files (found {unique_values})."
+            assert len(unique_values) == 1, f"{property_message} is not consistent over the files (found {unique_values})."
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -57,7 +57,7 @@ class TestMultiImagingExtractor(TestCase):
             (3, 4, 20.0, 2, "The number of channels is not consistent over the files (found {1, 2})."),
         ]
     )
-    def test_inconsistent_sampling_frequency_assertion(self, rows, columns, sampling_frequency, num_channels, msg):
+    def test_inconsistent_property_assertion(self, rows, columns, sampling_frequency, num_channels, msg):
         inconsistent_extractors = [
             self.extractors[0],
             generate_dummy_imaging_extractor(

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -80,6 +80,28 @@ class TestMultiImagingExtractor(TestCase):
         )
         assert_array_equal(test_frames, expected_frames)
 
+    def test_set_incorrect_times(self):
+        self.extractors[0].set_times(np.arange(0, 10) / 20.0)
+
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg="'times' should have the same length of the number of frames!",
+        ):
+            MultiImagingExtractor(imaging_extractors=self.extractors)
+
+        self.assertEqual(self.multi_imaging_extractor._times, None)
+
+    def test_set_times(self):
+        [extractor.set_times(np.arange(0, 10) / 20.0) for extractor in self.extractors]
+        multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=self.extractors)
+
+        dummy_times = list(np.arange(0, 10) / 20.0) * 3
+        assert_array_equal(multi_imaging_extractor._times, dummy_times)
+
+        self.multi_imaging_extractor.set_times(times=dummy_times)
+
+        assert_array_equal(self.multi_imaging_extractor._times, dummy_times)
+
     @parameterized.expand(
         [
             param(

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -35,7 +35,7 @@ class TestMultiImagingExtractor(TestCase):
 
     def test_get_frames_assertion(self):
         with self.assertRaisesWith(
-            exc_type=AssertionError, exc_msg="'frame_idxs' range beyond number of available frames!"
+            exc_type=AssertionError, exc_msg="'frame_idxs' exceed number of frames"
         ):
             self.multi_imaging_extractor.get_frames(frame_idxs=[31])
 

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -14,8 +14,10 @@ class TestMultiImagingExtractor(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        dummy_extractor = generate_dummy_imaging_extractor(num_frames=10, rows=3, columns=4, sampling_frequency=20.0)
-        cls.extractors = [dummy_extractor] * 3
+        cls.extractors = [
+            generate_dummy_imaging_extractor(num_frames=10, rows=3, columns=4, sampling_frequency=20.0)
+            for _ in range(3)
+        ]
         cls.multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=cls.extractors)
 
     def test_get_image_size(self):

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -39,7 +39,8 @@ class TestMultiImagingExtractor(TestCase):
         with self.assertRaisesWith(exc_type=AssertionError, exc_msg="'frame_idxs' exceed number of frames"):
             self.multi_imaging_extractor.get_frames(frame_idxs=[31])
 
-    def test_get_frames(self):
+    def test_get_non_consecutive_frames(self):
+        test_frames = self.multi_imaging_extractor.get_frames(frame_idxs=[8, 10, 12, 15, 20, 29])
         expected_frames = np.concatenate(
             (
                 self.extractors[0].get_frames(frame_idxs=[8])[np.newaxis, ...],
@@ -48,7 +49,28 @@ class TestMultiImagingExtractor(TestCase):
             ),
             axis=0,
         )
-        assert_array_equal(self.multi_imaging_extractor.get_frames(frame_idxs=[8, 10, 12, 15, 20, 29]), expected_frames)
+        assert_array_equal(test_frames, expected_frames)
+
+    def test_get_consecutive_frames(self):
+        test_frames = self.multi_imaging_extractor.get_frames(frame_idxs=np.arange(16, 22))
+        expected_frames = np.concatenate(
+            (
+                self.extractors[1].get_frames(frame_idxs=np.arange(6, 10)),
+                self.extractors[2].get_frames(frame_idxs=[0, 1]),
+            ),
+            axis=0,
+        )
+
+        assert_array_equal(test_frames, expected_frames)
+
+    def test_get_all_frames(self):
+        test_frames = self.multi_imaging_extractor.get_frames(frame_idxs=np.arange(0, 30))
+        expected_frames = np.concatenate(
+            [extractor.get_frames(np.arange(0, 10)) for extractor in self.extractors],
+            axis=0,
+        )
+
+        assert_array_equal(test_frames, expected_frames)
 
     @parameterized.expand(
         [

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -52,17 +52,12 @@ class TestMultiImagingExtractor(TestCase):
 
     @parameterized.expand(
         [
-            (3, 4, 15.0, 1,
-             "The sampling frequency is not consistent over the files (found {20.0, 15.0})."),
-            (3, 5, 20.0, 1,
-             "The size of a frame is not consistent over the files (found {(3, 4), (3, 5)})."),
-            (3, 4, 20.0, 2,
-             "The number of channels is not consistent over the files (found {1, 2})."),
+            (3, 4, 15.0, 1, "The sampling frequency is not consistent over the files (found {20.0, 15.0})."),
+            (3, 5, 20.0, 1, "The size of a frame is not consistent over the files (found {(3, 4), (3, 5)})."),
+            (3, 4, 20.0, 2, "The number of channels is not consistent over the files (found {1, 2})."),
         ]
     )
-    def test_inconsistent_sampling_frequency_assertion(self, rows, columns,
-                                                       sampling_frequency, num_channels,
-                                                       msg):
+    def test_inconsistent_sampling_frequency_assertion(self, rows, columns, sampling_frequency, num_channels, msg):
         inconsistent_extractors = [
             self.extractors[0],
             generate_dummy_imaging_extractor(
@@ -74,8 +69,8 @@ class TestMultiImagingExtractor(TestCase):
             ),
         ]
         with self.assertRaisesWith(
-                exc_type=AssertionError,
-                exc_msg=msg,
+            exc_type=AssertionError,
+            exc_msg=msg,
         ):
             MultiImagingExtractor(imaging_extractors=inconsistent_extractors)
 

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -15,7 +15,7 @@ class TestMultiImagingExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.extractors = [
-            generate_dummy_imaging_extractor(num_frames=10, rows=3, columns=4, sampling_frequency=20.0)
+            generate_dummy_imaging_extractor(num_frames=10, num_rows=3, num_columns=4, sampling_frequency=20.0)
             for _ in range(3)
         ]
         cls.multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=cls.extractors)
@@ -132,8 +132,8 @@ class TestMultiImagingExtractor(TestCase):
             self.extractors[0],
             generate_dummy_imaging_extractor(
                 num_frames=1,
-                rows=rows,
-                columns=columns,
+                num_rows=rows,
+                num_columns=columns,
                 sampling_frequency=sampling_frequency,
                 num_channels=num_channels,
             ),

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -72,6 +72,14 @@ class TestMultiImagingExtractor(TestCase):
 
         assert_array_equal(test_frames, expected_frames)
 
+    def test_get_video(self):
+        test_frames = self.multi_imaging_extractor.get_video()
+        expected_frames = np.concatenate(
+            [self.extractors[i].get_video() for i in range(3)],
+            axis=0,
+        )
+        assert_array_equal(test_frames, expected_frames)
+
     @parameterized.expand(
         [
             param(

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -1,0 +1,84 @@
+import unittest
+
+import numpy as np
+from hdmf.testing import TestCase
+from numpy.testing import assert_array_equal
+from parameterized import parameterized
+
+from roiextractors.multiimagingextractor import MultiImagingExtractor
+from roiextractors.testing import generate_dummy_imaging_extractor
+
+
+class TestMultiImagingExtractor(TestCase):
+    extractors = None
+
+    @classmethod
+    def setUpClass(cls):
+        dummy_extractor = generate_dummy_imaging_extractor(num_frames=10, rows=3, columns=4, sampling_frequency=20.0)
+        cls.extractors = [dummy_extractor] * 3
+        cls.multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=cls.extractors)
+
+    def test_get_image_size(self):
+        assert self.multi_imaging_extractor.get_image_size() == self.extractors[0].get_image_size()
+
+    def test_get_num_frames(self):
+        assert self.multi_imaging_extractor.get_num_frames() == 30
+
+    def test_get_sampling_frequency(self):
+        assert self.multi_imaging_extractor.get_sampling_frequency() == 20.0
+
+    def test_get_channel_names(self):
+        assert self.multi_imaging_extractor.get_channel_names() == ["channel_num_0"]
+
+    def test_get_num_channels(self):
+        assert self.multi_imaging_extractor.get_num_channels() == 1
+
+    def test_get_frames_assertion(self):
+        with self.assertRaisesWith(
+            exc_type=AssertionError, exc_msg="'frame_idxs' range beyond number of available frames!"
+        ):
+            self.multi_imaging_extractor.get_frames(frame_idxs=[31])
+
+    def test_get_frames(self):
+        expected_frames = np.concatenate(
+            (
+                self.extractors[0].get_frames(frame_idxs=[8])[np.newaxis, ...],
+                self.extractors[1].get_frames(frame_idxs=[0, 2, 5]),
+                self.extractors[2].get_frames(frame_idxs=[0, 9]),
+            ),
+            axis=0,
+        )
+        assert_array_equal(self.multi_imaging_extractor.get_frames(frame_idxs=[8, 10, 12, 15, 20, 29]), expected_frames)
+
+    @parameterized.expand(
+        [
+            (3, 4, 15.0, 1,
+             "The sampling frequency is not consistent over the files (found {20.0, 15.0})."),
+            (3, 5, 20.0, 1,
+             "The size of a frame is not consistent over the files (found {(3, 4), (3, 5)})."),
+            (3, 4, 20.0, 2,
+             "The number of channels is not consistent over the files (found {1, 2})."),
+        ]
+    )
+    def test_inconsistent_sampling_frequency_assertion(self, rows, columns,
+                                                       sampling_frequency, num_channels,
+                                                       msg):
+        inconsistent_extractors = [
+            self.extractors[0],
+            generate_dummy_imaging_extractor(
+                num_frames=1,
+                rows=rows,
+                columns=columns,
+                sampling_frequency=sampling_frequency,
+                num_channels=num_channels,
+            ),
+        ]
+        with self.assertRaisesWith(
+                exc_type=AssertionError,
+                exc_msg=msg,
+        ):
+            MultiImagingExtractor(imaging_extractors=inconsistent_extractors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -81,21 +81,22 @@ class TestMultiImagingExtractor(TestCase):
         assert_array_equal(test_frames, expected_frames)
 
     def test_set_incorrect_times(self):
-        self.extractors[0].set_times(np.arange(0, 10) / 20.0)
-
         with self.assertRaisesWith(
             exc_type=AssertionError,
             exc_msg="'times' should have the same length of the number of frames!",
         ):
-            MultiImagingExtractor(imaging_extractors=self.extractors)
+            self.multi_imaging_extractor.set_times(times=np.arange(0, 10) / 30.0)
 
         self.assertEqual(self.multi_imaging_extractor._times, None)
 
     def test_set_times(self):
-        [extractor.set_times(np.arange(0, 10) / 20.0) for extractor in self.extractors]
+        self.extractors[1].set_times(np.arange(0, 10) / 30.0)
         multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=self.extractors)
 
-        dummy_times = list(np.arange(0, 10) / 20.0) * 3
+        dummy_times = np.arange(0, 30) / 20.0
+        to_replace = [*range(multi_imaging_extractor._start_frames[1], multi_imaging_extractor._end_frames[1])]
+
+        dummy_times[to_replace] = self.extractors[1]._times
         assert_array_equal(multi_imaging_extractor._times, dummy_times)
 
         self.multi_imaging_extractor.set_times(times=dummy_times)


### PR DESCRIPTION
This PR introduces a new extractor object that can be used to combine multiple ImagingExtractors into to one continuous ImagingExtractor to be written to the same TwoPhotonSeries object.


Resolve #119 