### PR TITLE
Add dummy imaging_extractor

### DIFF
--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -50,10 +50,10 @@ class NumpyImagingExtractor(ImagingExtractor):
         self._channel_names = channel_names
 
         (
-            self._num_channels,
             self._num_frames,
             self._size_x,
             self._size_y,
+            self._num_channels,
         ) = get_video_shape(self._video)
 
         if len(self._video.shape) == 3:

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -14,18 +14,30 @@ inttype = (int, np.integer)
 import numpy as np
 
 from roiextractors import NumpyImagingExtractor
+from roiextractors.extraction_tools import DtypeType
 
 
 def generate_dummy_imaging_extractor(
-    num_frames: int = 100,
+    num_frames: int = 30,
     rows: int = 10,
     columns: int = 10,
     num_channels: int = 1,
-    sampling_frequency: float = 30000,
-    dtype="int16",
+    sampling_frequency: float = 30,
+    dtype: DtypeType = "uint16",
 ):
     channel_names = [f"channel_num_{num}" for num in range(num_channels)]
-    video = np.random.randint(low=0, high=256, size=(num_frames, rows, columns, num_channels)).astype(dtype)
+
+    dtype = np.dtype(dtype)
+    number_of_bytes = dtype.itemsize
+
+    low = 0 if "u" in dtype.name else 2 ** (number_of_bytes - 1) - 2**number_of_bytes
+    high = 2**number_of_bytes - 1 if "u" in dtype.name else 2**number_of_bytes - 2 ** (number_of_bytes - 1) - 1
+    size = (num_frames, rows, columns, num_channels)
+    video = (
+        np.random.random(size=size)
+        if "float" in dtype.name
+        else np.random.randint(low=low, high=high, size=size, dtype=dtype)
+    )
 
     imaging_extractor = NumpyImagingExtractor(
         timeseries=video, sampling_frequency=sampling_frequency, channel_names=channel_names

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -11,6 +11,29 @@ floattype = (float, np.floating)
 inttype = (int, np.integer)
 
 
+import numpy as np
+
+from roiextractors import NumpyImagingExtractor
+
+
+def generate_dummy_imaging_extractor(
+    num_frames: int = 100,
+    rows: int = 10,
+    columns: int = 10,
+    num_channels: int = 1,
+    sampling_frequency: float = 30000,
+    dtype="int16",
+):
+    channel_names = [f"channel_num_{num}" for num in range(num_channels)]
+    video = np.random.randint(low=0, high=256, size=(num_frames, rows, columns, num_channels)).astype(dtype)
+
+    imaging_extractor = NumpyImagingExtractor(
+        timeseries=video, sampling_frequency=sampling_frequency, channel_names=channel_names
+    )
+
+    return imaging_extractor
+
+
 def _assert_iterable_shape(iterable, shape):
     ar = iterable if isinstance(iterable, np.ndarray) else np.array(iterable)
     for ar_shape, given_shape in zip(ar.shape, shape):


### PR DESCRIPTION
For creating test here and in `nwb-conversion-tools` let's mimic spike interface functionality to add simple artificial dummy extractors that are easy to create and test. This PR pushes one for `imaging_extractors`. A similar one will be added for the homologous segmentation structure in a further PR. 

Also, I changed the numpy extractor to conform to the now agreed upon image format of (frames, rows, columns, channels).