### PR TITLE
Add channel argument to preserve backwards compability in `memmapextractors`

### DIFF
--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -35,7 +35,7 @@ except ImportError:
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]
-NumpyArray = Union[np.ndarray, np.memmap]
+NumpyArray = np.ndarray
 DtypeType = Union[str, np.dtype]
 IntType = Union[int, np.integer]
 FloatType = float

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -35,7 +35,7 @@ except ImportError:
 
 ArrayType = Union[list, np.array]
 PathType = Union[str, Path]
-NumpyArray = Union[np.array, np.memmap]
+NumpyArray = Union[np.ndarray, np.memmap]
 DtypeType = Union[str, np.dtype]
 IntType = Union[int, np.integer]
 FloatType = float

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -21,14 +21,14 @@ class MemmapImagingExtractor(ImagingExtractor):
     def __init__(
         self,
         video,
-    ):
+    ) -> None:
         """
         Abstract class for memmapable imaging extractors.
         """
         self._video = video
         super().__init__()
 
-    def get_frames(self, frame_idxs=None, channel: Optional[int] = 0) -> NumpyArray:
+    def get_frames(self, frame_idxs=None, channel: Optional[int] = 0) -> np.ndarray:
         if frame_idxs is None:
             frame_idxs = [frame for frame in range(self.get_num_frames())]
 
@@ -40,7 +40,7 @@ class MemmapImagingExtractor(ImagingExtractor):
 
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: Optional[int] = 0
-    ) -> NumpyArray:
+    ) -> np.ndarray:
         frame_idxs = range(start_frame, end_frame)
         return self.get_frames(frame_idxs=frame_idxs, channel=channel)
 

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -27,17 +27,19 @@ class MemmapImagingExtractor(ImagingExtractor):
         self._video = video
         super().__init__()
 
-    def get_frames(self, frame_idxs=None):
+    def get_frames(self, frame_idxs=None, channel: int = 0):
         if frame_idxs is None:
             frame_idxs = [frame for frame in range(self.get_num_frames())]
 
         frames = self._video.take(indices=frame_idxs, axis=0)
+        if channel is not None:
+            frames = frames[:, :, :, channel].squeeze()
 
         return frames
 
-    def get_video(self, start_frame: int = None, end_frame: int = None) -> np.array:
+    def get_video(self, start_frame: int = None, end_frame: int = None, channel: int = 0) -> np.array:
         frame_idxs = range(start_frame, end_frame)
-        return self.get_frames(frame_idxs=frame_idxs)
+        return self.get_frames(frame_idxs=frame_idxs, channel=channel)
 
     def get_image_size(self):
         return (self._rows, self._columns)
@@ -120,7 +122,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         )
 
         if file_size_in_bytes < buffer_size_in_bytes:
-            video_data_to_save = imaging.get_frames()
+            video_data_to_save = imaging.get_frames(channel=None)
             video_memmap[:] = video_data_to_save
 
         else:
@@ -143,7 +145,7 @@ class MemmapImagingExtractor(ImagingExtractor):
                 end_frame = min(frame + frames_in_buffer, num_frames)
 
                 # Get the video chunk
-                video_chunk = imaging.get_video(start_frame=start_frame, end_frame=end_frame)
+                video_chunk = imaging.get_video(start_frame=start_frame, end_frame=end_frame, channel=None)
 
                 # Fit the video chunk in the memmap array
                 video_memmap[start_frame:end_frame, ...] = video_chunk

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -10,6 +10,7 @@ from typing import Tuple, Dict, Optional
 from ...extraction_tools import (
     PathType,
     DtypeType,
+    NumpyArray,
 )
 
 
@@ -27,7 +28,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         self._video = video
         super().__init__()
 
-    def get_frames(self, frame_idxs=None, channel: int = 0):
+    def get_frames(self, frame_idxs=None, channel: Optional[int] = 0) -> NumpyArray:
         if frame_idxs is None:
             frame_idxs = [frame for frame in range(self.get_num_frames())]
 
@@ -37,17 +38,19 @@ class MemmapImagingExtractor(ImagingExtractor):
 
         return frames
 
-    def get_video(self, start_frame: int = None, end_frame: int = None, channel: int = 0) -> np.array:
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: Optional[int] = 0
+    ) -> NumpyArray:
         frame_idxs = range(start_frame, end_frame)
         return self.get_frames(frame_idxs=frame_idxs, channel=channel)
 
-    def get_image_size(self):
+    def get_image_size(self) -> Tuple[int, int]:
         return (self._rows, self._columns)
 
-    def get_num_frames(self):
+    def get_num_frames(self) -> int:
         return self._num_frames
 
-    def get_sampling_frequency(self):
+    def get_sampling_frequency(self) -> float:
         return self._sampling_frequency
 
     def get_channel_names(self):
@@ -60,7 +63,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         """
         pass
 
-    def get_num_channels(self):
+    def get_num_channels(self) -> int:
         """Total number of active channels in the recording
 
         Returns
@@ -73,7 +76,7 @@ class MemmapImagingExtractor(ImagingExtractor):
     def get_dtype(self) -> DtypeType:
         return self.dtype
 
-    def get_video_shape(self):
+    def get_video_shape(self) -> Tuple[int, int, int, int]:
 
         return (self._num_frames, self._rows, self._columns, self._num_channels)
 
@@ -83,7 +86,7 @@ class MemmapImagingExtractor(ImagingExtractor):
         save_path: PathType,
         verbose: bool = False,
         buffer_size_in_gb: Optional[float] = None,
-    ):
+    ) -> None:
         """
         Static method to write imaging.
 


### PR DESCRIPTION
I am adding this argument to keep backwards compatibility with the previous `get_frames` policy of returning only a channel of the signal (see #121 for a more general discussion).