### PR TITLE
[Refactor] standardize video structures

### DIFF
--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -260,14 +260,19 @@ def _image_mask_extractor(pixel_mask, _roi_ids, image_shape):
     return image_mask
 
 
-def get_video_shape(video):
-    if len(video.shape) == 3:
-        # 1 channel
+def get_video_shape(video) -> Union[Tuple[int, int, int], Tuple[int, int, int, int]]:
+    """Return the shape of the video according to the standardized structure of (frames, rows, columns, channels)."""
+    n_dims = len(video.shape)
+    if n_dims == 3:
         num_channels = 1
         num_frames, size_x, size_y = video.shape
+    elif n_dims == 4:
+        num_frames, size_x, size_y, num_channels = video.shape
     else:
-        num_channels, num_frames, size_x, size_y = video.shape
-    return num_channels, num_frames, size_x, size_y
+        raise NotImplementedError(
+            "Tool function 'get_video_shape' cannot handle videos with a number of dimensions other than 3 or 4!"
+        )
+    return num_frames, size_x, size_y, num_channels
 
 
 def check_get_frames_args(func):

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -69,10 +69,10 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             self.metadata = metadata
 
         (
-            self._num_channels,
             self._num_frames,
             self._size_x,
             self._size_y,
+            self._num_channels,
         ) = get_video_shape(self._video)
 
         if len(self._video.shape) == 3:

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -1,3 +1,4 @@
+"""A standard interface for reading Imaging and Segmentation data with numpy arrays, either on disk or in memory."""
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,8 @@ from ...segmentationextractor import SegmentationExtractor
 
 
 class NumpyImagingExtractor(ImagingExtractor):
+    """Reads Imaging data from numpy arrays, either on disk or in memory."""
+
     extractor_name = "NumpyImagingExtractor"
     installed = True
     is_writable = True
@@ -44,21 +47,11 @@ class NumpyImagingExtractor(ImagingExtractor):
         else:
             raise TypeError("'timeseries' can be a str or a numpy array")
 
-        self._sampling_frequency = float(sampling_frequency)
-
-        self._sampling_frequency = sampling_frequency
-        self._channel_names = channel_names
-
-        (
-            self._num_frames,
-            self._size_x,
-            self._size_y,
-            self._num_channels,
-        ) = get_video_shape(self._video)
-
         if len(self._video.shape) == 3:
-            # check if this converts to np.ndarray
-            self._video = self._video[np.newaxis, :]
+            self._video = self._video[..., np.newaxis]
+        self._sampling_frequency = float(sampling_frequency)
+        self._channel_names = channel_names
+        self._num_frames, self._size_x, self._size_y, self._num_channels = get_video_shape(self._video)
 
         if self._channel_names is not None:
             assert len(self._channel_names) == self._num_channels, (
@@ -81,23 +74,9 @@ class NumpyImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self):
-        """List of  channels in the recoding.
-
-        Returns
-        -------
-        channel_names: list
-            List of strings of channel names
-        """
         return self._channel_names
 
     def get_num_channels(self):
-        """Total number of active channels in the recording
-
-        Returns
-        -------
-        no_of_channels: int
-            integer count of number of channels
-        """
         return self._num_channels
 
     @staticmethod

--- a/tests/test_internals/test_extraction_tools.py
+++ b/tests/test_internals/test_extraction_tools.py
@@ -5,8 +5,33 @@ from itertools import product
 
 import numpy as np
 from parameterized import parameterized, param
+from hdmf.testing import TestCase
 
-from roiextractors.extraction_tools import VideoStructure, read_numpy_memmap_video
+from roiextractors.extraction_tools import VideoStructure, read_numpy_memmap_video, get_video_shape
+
+
+class TestGetVideoShapeAssertion(TestCase):
+    def test_get_video_shape_assertion(self):
+        with self.assertRaisesWith(
+            exc_type=NotImplementedError,
+            exc_msg=(
+                "Tool function 'get_video_shape' cannot handle videos with a number of dimensions other than 3 or 4!"
+            ),
+        ):
+            video = np.zeros(shape=(1, 1))
+            get_video_shape(video=video)
+
+
+def test_get_video_shape_3_dims():
+    shape = [5, 3, 2]
+    video = np.zeros(shape=shape)
+    assert get_video_shape(video=video) == tuple(shape + [1])
+
+
+def test_get_video_shape_4_dims():
+    shape = (5, 3, 2, 3)
+    video = np.zeros(shape=shape)
+    assert get_video_shape(video=video) == shape
 
 
 class TestVideoStructureClass(unittest.TestCase):


### PR DESCRIPTION
@h-mayorquin First attempts to start the process of standardizing internal tools and data access patterns to the new standard.

For the ImagingExtractor inits, however, careful attention must be given to the source data structure (which may not be our 'canonical' form). As such, we may want to start using the `VideoStructure` to resolve the mapping for all these cases.