### PR TITLE
Refactor nwb extractor frames and tests

### DIFF
--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -83,14 +83,12 @@ class NwbImagingExtractor(ImagingExtractor):
         # Load the two video structures that TwoPhotonSeries supports.
         self._data_has_channels_axis = True
         if len(self.two_photon_series.data.shape) == 3:
-            self._data_has_channels_axis = False
             self._num_channels = 1
-            self._num_frames, self._rows, self._columns = self.two_photon_series.data.shape
+            self._num_frames, self._columns, self._rows = self.two_photon_series.data.shape
         else:
-            self._num_frames, self._rows, self._columns, self._num_channels = self.two_photon_series.data.shape
-            raise "videos with multiple channel not supported yet"
+            raise "TwoPhothonSeries with depth dimension (z) not supported"
 
-        # Set channel names
+        # Set channel names (This should disambiguate which optical channel)
         self._channel_names = [i.name for i in self.two_photon_series.imaging_plane.optical_channel]
 
         # Set sampling frequency
@@ -161,13 +159,11 @@ class NwbImagingExtractor(ImagingExtractor):
             slice_stop = self.get_num_frames()
 
         data = self.two_photon_series.data
+        frames = data[slice_start:slice_stop, ...].transpose([0, 2, 1])
 
-        if self._data_has_channels_axis and channel is not None:
-            frames = data[slice_start:slice_stop, :, :, channel]
-        else:
-            frames = data[slice_start:slice_stop, ...]
-
-        return frames.squeeze()
+        if isinstance(frame_idxs, int):
+            frames = frames.squeeze()
+        return frames
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0):
         start_frame = start_frame if start_frame is not None else 0

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from typing import Tuple
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -17,6 +18,21 @@ from roiextractors import NumpyImagingExtractor
 from roiextractors.extraction_tools import DtypeType
 
 
+def generate_dummy_video(size: Tuple[int], dtype: DtypeType = "uint16"):
+    dtype = np.dtype(dtype)
+    number_of_bytes = dtype.itemsize
+
+    low = 0 if "u" in dtype.name else 2 ** (number_of_bytes - 1) - 2**number_of_bytes
+    high = 2**number_of_bytes - 1 if "u" in dtype.name else 2**number_of_bytes - 2 ** (number_of_bytes - 1) - 1
+    video = (
+        np.random.random(size=size)
+        if "float" in dtype.name
+        else np.random.randint(low=low, high=high, size=size, dtype=dtype)
+    )
+
+    return video
+
+
 def generate_dummy_imaging_extractor(
     num_frames: int = 30,
     rows: int = 10,
@@ -27,17 +43,8 @@ def generate_dummy_imaging_extractor(
 ):
     channel_names = [f"channel_num_{num}" for num in range(num_channels)]
 
-    dtype = np.dtype(dtype)
-    number_of_bytes = dtype.itemsize
-
-    low = 0 if "u" in dtype.name else 2 ** (number_of_bytes - 1) - 2**number_of_bytes
-    high = 2**number_of_bytes - 1 if "u" in dtype.name else 2**number_of_bytes - 2 ** (number_of_bytes - 1) - 1
     size = (num_frames, rows, columns, num_channels)
-    video = (
-        np.random.random(size=size)
-        if "float" in dtype.name
-        else np.random.randint(low=low, high=high, size=size, dtype=dtype)
-    )
+    video = generate_dummy_video(size=size, dtype=dtype)
 
     imaging_extractor = NumpyImagingExtractor(
         timeseries=video, sampling_frequency=sampling_frequency, channel_names=channel_names

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -196,7 +196,9 @@ def check_imaging_equal(imaging_extractor1: ImagingExtractor, imaging_extractor2
     assert np.isclose(imaging_extractor1.get_sampling_frequency(), imaging_extractor2.get_sampling_frequency())
     assert_array_equal(imaging_extractor1.get_channel_names(), imaging_extractor2.get_channel_names())
     assert_array_equal(imaging_extractor1.get_image_size(), imaging_extractor2.get_image_size())
-    assert_array_equal(imaging_extractor1.get_frames(frame_idxs=[0]), imaging_extractor2.get_frames(frame_idxs=[0]))
+    assert_array_equal(
+        imaging_extractor1.get_frames(frame_idxs=[0, 1]), imaging_extractor2.get_frames(frame_idxs=[0, 1])
+    )
     assert_array_almost_equal(
         imaging_extractor1.frame_to_time(np.arange(imaging_extractor1.get_num_frames())),
         imaging_extractor2.frame_to_time(np.arange(imaging_extractor2.get_num_frames())),

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -1,0 +1,96 @@
+import unittest
+from tempfile import mkdtemp
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from pynwb import NWBFile, TimeSeries, NWBHDF5IO
+from pynwb.image import ImageSeries
+from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation
+
+from roiextractors import NwbImagingExtractor
+
+
+class TestNwbImagingExtractor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session_start_time = datetime.now()
+        self.file_path = Path(mkdtemp()) / "test_nwb_imaging_extractor.nwb"
+
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="file_id",
+            session_start_time=self.session_start_time,
+        )
+        self.device = self.nwbfile.create_device(
+            name="Microscope", description="My two-photon microscope", manufacturer="The best microscope manufacturer"
+        )
+        self.optical_channel = OpticalChannel(
+            name="OpticalChannel", description="an optical channel", emission_lambda=500.0
+        )
+
+        self.sampling_frequency = 30.0
+        self.num_frames = 30
+        self.rows = 50
+        self.columns = 25
+        self.num_channels = 1
+
+        self.video_shape = (self.num_frames, self.rows, self.columns, self.num_channels)
+        self.image_size = (self.rows, self.columns)
+
+        self.dtype = "uint"
+        self.video = np.random.randint(low=0, high=256, size=self.video_shape).astype(self.dtype)
+
+        self.imaging_plane = self.nwbfile.create_imaging_plane(
+            name="ImagingPlane",
+            optical_channel=self.optical_channel,
+            imaging_rate=self.sampling_frequency,
+            description="a very interesting part of the brain",
+            device=self.device,
+            excitation_lambda=600.0,
+            indicator="GFP",
+            location="V1",
+            grid_spacing=[0.01, 0.01],
+            grid_spacing_unit="meters",
+            origin_coords=[1.0, 2.0, 3.0],
+            origin_coords_unit="meters",
+        )
+
+        # using internal data. this data will be stored inside the NWB file
+        self.image_series1 = TwoPhotonSeries(
+            name="TwoPhotonSeries1",
+            data=self.video,
+            imaging_plane=self.imaging_plane,
+            rate=self.sampling_frequency,
+            unit="normalized amplitude",
+        )
+
+        self.nwbfile.add_acquisition(self.image_series1)
+
+        with NWBHDF5IO(self.file_path, "w") as io:
+            io.write(self.nwbfile)
+
+    def test_basic_setup(self):
+
+        nwb_imaging_extractor = NwbImagingExtractor(file_path=self.file_path, optical_series_name=None)
+
+        image_size = nwb_imaging_extractor.get_image_size()
+        num_frames = nwb_imaging_extractor.get_num_frames()
+        num_channels = nwb_imaging_extractor.get_num_channels()
+
+        expected_image_size = self.image_size
+        expected_num_frames = self.num_frames
+        expected_num_channels = self.num_channels
+
+        assert image_size == expected_image_size
+        assert num_frames == expected_num_frames
+        assert num_channels == expected_num_channels
+
+        video = nwb_imaging_extractor.get_video()
+        expected_video = self.video
+
+        np.testing.assert_array_almost_equal(video, expected_video)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -57,7 +57,7 @@ class TestNwbImagingExtractor(unittest.TestCase):
         # using internal data. this data will be stored inside the NWB file
         self.image_series = TwoPhotonSeries(
             name="TwoPhotonSeries",
-            data=self.video,
+            data=self.video.transpose([0, 2, 1]),
             imaging_plane=self.imaging_plane,
             rate=self.sampling_frequency,
             unit="normalized amplitude",
@@ -88,6 +88,11 @@ class TestNwbImagingExtractor(unittest.TestCase):
         frames_with_scalar = nwb_imaging_extractor.get_frames(frame_idxs)
         expected_frames = self.video[frame_idxs, ...]
         np.testing.assert_array_almost_equal(frames_with_scalar, expected_frames)
+
+        frame_idxs = [0]
+        frames_with_singleton = nwb_imaging_extractor.get_frames(frame_idxs)
+        expected_frames = self.video[frame_idxs, ...]
+        np.testing.assert_array_almost_equal(frames_with_singleton, expected_frames)
 
         frame_idxs = [0, 1]
         frames_with_list = nwb_imaging_extractor.get_frames(frame_idxs)


### PR DESCRIPTION
This is the first attempt at getting correct frames in `nwb_extractor`. This branch should be tested in `nwb-conversion-tools` to see if everything works as we expected over there.  I refactored the function and added a test to see that it works as expected.

I intend to add a test to support loading `TwoPhotonTimeSeries` with channels but that's not the priority right now. 