### PR TITLE
Proposal for standardizing data format piecewise.

### DIFF
--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -81,4 +81,4 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         self._num_frames, self._rows, self._columns, self._num_channels = self._video.shape
 
         super().__init__(video=self._video)
-        self._images_in_standard_structure = False
+        self._images_in_standard_structure = True

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -81,3 +81,4 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         self._num_frames, self._rows, self._columns, self._num_channels = self._video.shape
 
         super().__init__(video=self._video)
+        self._images_in_standard_structure = False

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -22,6 +22,7 @@ class NumpyImagingExtractor(ImagingExtractor):
         channel_names: ArrayType = None,
     ):
         ImagingExtractor.__init__(self)
+        self._images_in_standard_structure = True
 
         if isinstance(timeseries, (str, Path)):
             timeseries = Path(timeseries)

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -25,6 +25,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         BaseExtractor.__init__(self)
         assert self.installed, self.installation_mesg
         self._memmapped = False
+        self._images_in_standard_structure = False
 
     @abstractmethod
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.ndarray:
@@ -70,6 +71,9 @@ class ImagingExtractor(ABC, BaseExtractor):
     @check_get_videos_args
     def get_video(self, start_frame: int = None, end_frame: int = None, channel: int = 0) -> np.ndarray:
         return self.get_frames(range(start_frame, end_frame), channel)
+
+    def get_video_shape(self):
+        return self.get_frames(frame_idxs=[0], channel=None).shape
 
     def frame_to_time(self, frames: Union[FloatType, np.ndarray]) -> Union[FloatType, np.ndarray]:
         """This function converts user-inputted frame indexes to times with units of seconds.

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -73,7 +73,12 @@ class ImagingExtractor(ABC, BaseExtractor):
         return self.get_frames(range(start_frame, end_frame), channel)
 
     def get_video_shape(self):
-        return self.get_frames(frame_idxs=[0], channel=None).shape
+        more_frames_than_num_channels = self.get_num_channels() + 1
+        frame_idxs = [_ for _ in range(more_frames_than_num_channels)]
+        video_shape = np.array(self.get_frames(frame_idxs=frame_idxs, channel=None).shape)
+        video_shape[video_shape == more_frames_than_num_channels] = self.get_num_frames()
+
+        return tuple(video_shape)
 
     def frame_to_time(self, frames: Union[FloatType, np.ndarray]) -> Union[FloatType, np.ndarray]:
         """This function converts user-inputted frame indexes to times with units of seconds.

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -73,10 +73,17 @@ class ImagingExtractor(ABC, BaseExtractor):
         return self.get_frames(range(start_frame, end_frame), channel)
 
     def get_video_shape(self):
-        more_frames_than_num_channels = self.get_num_channels() + 1
-        frame_idxs = [_ for _ in range(more_frames_than_num_channels)]
+        rows, columns = self.get_image_size()
+        num_channels = self.get_num_channels()
+        unique_frame_value = num_channels + 1
+        if unique_frame_value == rows:
+            unique_frame_value += 1
+        if unique_frame_value == columns:
+            unique_frame_value += 1
+
+        frame_idxs = [_ for _ in range(unique_frame_value)]
         video_shape = np.array(self.get_frames(frame_idxs=frame_idxs, channel=None).shape)
-        video_shape[video_shape == more_frames_than_num_channels] = self.get_num_frames()
+        video_shape[video_shape == unique_frame_value] = self.get_num_frames()
 
         return tuple(video_shape)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -79,8 +79,6 @@ class TestExtractors(TestCase):
         except NotImplementedError:
             return
 
-
-
     segmentation_extractor_list = [
         param(
             extractor_class=CaimanSegmentationExtractor,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -94,6 +94,16 @@ class TestExtractors(TestCase):
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
     def test_imaging_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
+
+        # Test for standard structure
+        if extractor._images_in_standard_structure:
+            num_frames = extractor.get_num_frames()
+            rows, columns = extractor.get_image_size()
+            num_channels = extractor.get_num_channels()
+            expected_video_shape = (num_frames, rows, columns, num_channels)
+            assert expected_video_shape == extractor.get_video_shape()
+
+        # Test round trip if write_method implemented
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix
             output_path = self.savedir / f"{extractor_class.__name__}{suffix}"


### PR DESCRIPTION
Following the comment in #132:

> I was thinking that we could do this piece wise by adding a general flag to the base class of ImagingExtractor. Something like self.standard_format=False (or something shorter). Then we add the flag at the __init__ of the classes where we can promise that as True and add a general test that goes over all the classes that have this flag and test they do uphold their contract.

> The advantage of this is that we have some explicit condition for the contract and also we can just leave it false if in the future we encounter some interface that is hard to reshape.

Here is the proposal in a PR for this. I will do a chain PR to this for `Hdf5ImagingExtractor`.