### PR TITLE
add typing information to `frame_slice in base` class

### DIFF
--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -128,7 +128,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         if extractor._times is not None:
             self.set_times(deepcopy(extractor._times))
 
-    def frame_slice(self, start_frame: int = None, end_frame: int = None):
+    def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         """Return a new ImagingExtractor ranging from the start_frame to the end_frame."""
         return FrameSliceImagingExtractor(parent_imaging=self, start_frame=start_frame, end_frame=end_frame)
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -128,7 +128,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         if extractor._times is not None:
             self.set_times(deepcopy(extractor._times))
 
-    def frame_slice(self, start_frame, end_frame):
+    def frame_slice(self, start_frame: int = None, end_frame: int = None):
         """Return a new ImagingExtractor ranging from the start_frame to the end_frame."""
         return FrameSliceImagingExtractor(parent_imaging=self, start_frame=start_frame, end_frame=end_frame)
 


### PR DESCRIPTION
This was missing in the frame slice PR. The class has the possibility to set start_frame and end_frame to None but not the function in the base class. 