### PR TITLE
MultiImagingExtractor to enable querying different slices of frames

### DIFF
--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -86,19 +86,13 @@ class TestMultiImagingExtractor(TestCase):
         )
         expected_frames = np.concatenate(
             (
-                self.extractors[1].get_frames(frame_idxs=[np.arange(0, 3), np.arange(6, 9)]),
-                np.concatenate(
-                    (
-                        self.extractors[1].get_frames(frame_idxs=[9])[np.newaxis, ...],
-                        self.extractors[2].get_frames(frame_idxs=[0, 1]),
-                    ),
-                    axis=0,
-                )[:, :, 0][np.newaxis, ...],
+                self.extractors[1].get_frames(frame_idxs=[0, 1, 2, 6, 7, 8, 9]),
+                self.extractors[2].get_frames(frame_idxs=[0, 1]),
             ),
             axis=0,
         )
 
-        assert_array_equal(test_frames[:, :, :, 0], expected_frames)
+        assert_array_equal(test_frames, expected_frames)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
This PR directly relates to #127, the reason why it is in a separate PR is to enhance the visibility of the changes in the `get_frames` method. 
The aim of this PR is to enable querying different slices of frames e.g.
`[[0,1,2,3], [10,11,22,25], [...]] `  just as it should work with numpy arrays. 

Is this use case justified?
