### PR TITLE
Raise NotImplementedError for formats lacking examples

### DIFF
--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -42,6 +42,15 @@ IntType = Union[int, np.integer]
 FloatType = float
 
 
+def raise_multi_channel_or_depth_not_implemented(extractor_name: str):
+    """Raise a NotImplementedError for an extractor that does not support multiple channels or depth (z-axis)."""
+    raise NotImplementedError(
+        f"The {extractor_name}Extractor does not currently support multiple color channels or 3-dimensional depth."
+        "If you with to request either of these features, please do so by raising an issue at "
+        "https://github.com/catalystneuro/roiextractors/issues"
+    )
+
+
 @dataclass
 class VideoStructure:
     """A data class for specifying the structure of a video.
@@ -323,14 +332,7 @@ def check_get_videos_args(func):
 
 
 def write_to_h5_dataset_format(
-    imaging,
-    dataset_path,
-    save_path=None,
-    file_handle=None,
-    dtype=None,
-    chunk_size=None,
-    chunk_mb=1000,
-    verbose=False,
+    imaging, dataset_path, save_path=None, file_handle=None, dtype=None, chunk_size=None, chunk_mb=1000, verbose=False,
 ):
     """Saves the video of an imaging extractor in an h5 dataset.
 
@@ -403,9 +405,7 @@ def write_to_h5_dataset_format(
                 chunks = range(n_chunk)
             for i in chunks:
                 video = imaging.get_video(
-                    start_frame=i * chunk_size,
-                    end_frame=min((i + 1) * chunk_size, num_frames),
-                    channel=ch,
+                    start_frame=i * chunk_size, end_frame=min((i + 1) * chunk_size, num_frames), channel=ch,
                 )
                 chunk_frames = np.squeeze(video).shape[0]
                 if dtype is not None:
@@ -434,12 +434,7 @@ def show_video(imaging, ax=None):
     im = ax.imshow(im0, interpolation="none", aspect="auto", vmin=0, vmax=1)
     interval = 1 / imaging.get_sampling_frequency() * 1000
     anim = animation.FuncAnimation(
-        fig,
-        animate_func,
-        frames=imaging.get_num_frames(),
-        fargs=(imaging, im, ax),
-        interval=interval,
-        blit=False,
+        fig, animate_func, frames=imaging.get_num_frames(), fargs=(imaging, im, ax), interval=interval, blit=False,
     )
     return anim
 

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -18,6 +18,7 @@ from ...extraction_tools import (
     ArrayType,
     check_get_frames_args,
     check_get_videos_args,
+    raise_multi_channel_or_depth_not_implemented,
 )
 from ...imagingextractor import ImagingExtractor
 from ...segmentationextractor import SegmentationExtractor
@@ -86,7 +87,7 @@ class NwbImagingExtractor(ImagingExtractor):
             self._num_channels = 1
             self._num_frames, self._columns, self._rows = self.two_photon_series.data.shape
         else:
-            raise "TwoPhothonSeries with depth dimension (z) not supported"
+            raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
 
         # Set channel names (This should disambiguate which optical channel)
         self._channel_names = [i.name for i in self.two_photon_series.imaging_plane.optical_channel]
@@ -142,10 +143,7 @@ class NwbImagingExtractor(ImagingExtractor):
                 institution=nwbfile.institution,
                 lab=nwbfile.lab,
             ),
-            Ophys=dict(
-                Device=[dict(name=dev) for dev in nwbfile.devices],
-                TwoPhotonSeries=[dict(name=opts.name)],
-            ),
+            Ophys=dict(Device=[dict(name=dev) for dev in nwbfile.devices], TwoPhotonSeries=[dict(name=opts.name)],),
         )
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0):

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ...extraction_tools import PathType, ArrayType
+from ...extraction_tools import PathType, ArrayType, raise_multi_channel_or_depth_not_implemented
 from ...extraction_tools import check_keys
 from ...imagingextractor import ImagingExtractor
 
@@ -122,6 +122,10 @@ class SbxImagingExtractor(ImagingExtractor):
         nplanes = self._info["nplanes"]
         nframes = (self._info["max_idx"] + 1) // nplanes
         shape = (nchannels, ncols, nrows, nplanes, nframes)
+
+        if nchannels != 1:
+            raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
+
         np_data = np.memmap(self.sbx_file_path, dtype="uint16", mode="r", shape=shape, order="F")
         return np_data
 

--- a/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractor/tiffimagingextractor.py
@@ -10,6 +10,7 @@ from ...extraction_tools import (
     check_get_frames_args,
     FloatType,
     ArrayType,
+    raise_multi_channel_or_depth_not_implemented,
 )
 
 from typing import Tuple
@@ -52,11 +53,7 @@ class TiffImagingExtractor(ImagingExtractor):
             self._num_frames, self._num_rows, self._num_cols = shape
             self._num_channels = 1
         else:
-            raise NotImplementedError(
-                "The TiffImagingExtracgtor does not currently support multiple color channels or 3-dimensional depth."
-                "If you with to request either of these features, please do so by raising an issue at "
-                "https://github.com/catalystneuro/roiextractors/issues"
-            )
+            raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
 
         self._kwargs = {
             "file_path": str(Path(file_path).absolute()),


### PR DESCRIPTION
None of our example data for the various proprietary formats include multiple channels, so we're really unable to be entirely sure about how to go about reading them in that case. `Tiff` may not be currently working as intended, `Sbx` might lead to incorrect data retrieval (if the memmap shape for the `.sbx` file is not correct), and `Nwb` raises an incorrect error type.

This PR standardized the error that gets raised in this case and leads the user to the issues on GitHub to request the feature (where we would also request they share the data to add to GIN).

For the non-proprietary numpy-related and HDF5 extractors we can, of course, make tests involving synthetic data on whatever axes we wish to specify, but this has also not really been done so far.