### PR TITLE
Fix `get_frames` behavior for single element list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Upcoming
+
+### Improvements
+* `get_video` is now an abstract method in `ImagingExtractor` [PR #180](https://github.com/catalystneuro/roiextractors/pull/180)
+
+### Features
+* Add dummy segmentation extractor [PR #176](https://github.com/catalystneuro/roiextractors/pull/176)
+
+
+### Testing
+* Added unittests to the `get_frames` method from `ImagingExtractors` to assert that they are consistent with numpy
+indexing behavior. [PR #154](https://github.com/catalystneuro/roiextractors/pull/154)
+* Tests for spikeinterface like-behavior for the `get_video` funtiction [PR #181](https://github.com/catalystneuro/roiextractors/pull/181)
+
+# v0.4.17

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -101,6 +101,8 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             slice_stop = self.get_num_frames()
 
         frames = self._video.lazy_slice[slice_start:slice_stop, :, :, channel]
+        if isinstance(frame_idxs, int):
+            frames = frames.dsetread().squeeze()
         return frames
 
     def get_image_size(self) -> Tuple[int, int]:

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -100,9 +100,9 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             slice_start = 0
             slice_stop = self.get_num_frames()
 
-        frames = self._video.lazy_slice[slice_start:slice_stop, :, :, channel]
+        frames = self._video.lazy_slice[slice_start:slice_stop, :, :, channel].dsetread()
         if isinstance(frame_idxs, int):
-            frames = frames.dsetread().squeeze()
+            frames = frames.squeeze()
         return frames
 
     def get_image_size(self) -> Tuple[int, int]:

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -34,7 +34,7 @@ class MemmapImagingExtractor(ImagingExtractor):
 
         frames = self._video.take(indices=frame_idxs, axis=0)
         if channel is not None:
-            frames = frames[:, :, :, channel].squeeze()
+            frames = frames[..., channel]
 
         return frames
 

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -131,14 +131,13 @@ class SbxImagingExtractor(ImagingExtractor):
             raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
 
         np_data = np.memmap(self.sbx_file_path, dtype="uint16", mode="r", shape=shape, order="F")
-        return np_data
+        return np_data.transpose(4, 2, 1, 0, 3)
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.array:
-        frames_list = []
-        for frame_no in frame_idxs:
-            frames_list.append(self._data[channel, :, :, 0, frame_no])
-        frame_out = np.stack(frames_list, axis=2).T.squeeze()
-        return np.iinfo("uint16").max - frame_out
+
+        frames = self._data.squeeze()[frame_idxs, ...]
+
+        return np.iinfo("uint16").max - frames
 
     def get_image_size(self) -> Tuple[int, int]:
         return tuple(self._info["sz"])

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -138,13 +138,12 @@ class SbxImagingExtractor(ImagingExtractor):
             raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
 
         np_data = np.memmap(self.sbx_file_path, dtype="uint16", mode="r", shape=shape, order="F")
-        return np_data.transpose(4, 2, 1, 0, 3)
+        return np_data
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.array:
+        frame_out = np.iinfo("uint16").max - self._data.transpose(4, 2, 1, 0, 3)[frame_idxs, :, :, channel, 0]
 
-        frames = self._data.squeeze()[frame_idxs, ...]
-
-        return np.iinfo("uint16").max - frames
+        return frame_out
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -75,13 +75,21 @@ class ScanImageTiffImagingExtractor(ImagingExtractor):
                 "https://github.com/catalystneuro/roiextractors/issues "
             )
 
-    @check_get_frames_args
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.ndarray:
+
+        squeeze_data = False
+        if isinstance(frame_idxs, int):
+            squeeze_data = True
+            frame_idxs = [frame_idxs]
+
         if not all(np.diff(frame_idxs) == 1):
             return np.concatenate([self._get_single_frame(idx=idx) for idx in frame_idxs])
         else:
             with ScanImageTiffReader(filename=str(self.file_path)) as io:
-                return io.data(beg=frame_idxs[0], end=frame_idxs[-1] + 1)
+                frames = io.data(beg=frame_idxs[0], end=frame_idxs[-1] + 1)
+                if squeeze_data:
+                    frames = frames.squeeze()
+            return frames
 
     def _get_single_frame(self, idx: int) -> np.ndarray:
         """

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -67,7 +67,6 @@ class TiffImagingExtractor(ImagingExtractor):
             "sampling_frequency": sampling_frequency,
         }
 
-    @check_get_frames_args
     def get_frames(self, frame_idxs, channel: int = 0):
         return self._video[frame_idxs, ...]
 

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -205,7 +205,7 @@ def check_imaging_equal(imaging_extractor1: ImagingExtractor, imaging_extractor2
     )
 
 
-def assert_get_frames_function_return_shapes(imaging_extractor: ImagingExtractor):
+def assert_get_frames_indexing_with_single_channel(imaging_extractor: ImagingExtractor):
     """Utiliy to check whether an ImagingExtractor get_frames function behaves as expected. We aim for the function to
     behave as numpy slicing and indexing as much as possible
 
@@ -216,19 +216,22 @@ def assert_get_frames_function_return_shapes(imaging_extractor: ImagingExtractor
     """
 
     image_size = imaging_extractor.get_image_size()
-    frames_with_scalar = imaging_extractor.get_frames(0, channel=0)
 
+    frame_idxs = 0
+    frames_with_scalar = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
     assert frames_with_scalar.shape == image_size
 
-    frames_with_single_element_list = imaging_extractor.get_frames([0], channel=0)
+    frame_idxs = [0]
+    frames_with_single_element_list = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
     assert frames_with_single_element_list.shape == (1, image_size[0], image_size[1])
 
-    frames_with_list = imaging_extractor.get_frames([0, 1], channel=0)
+    frame_idxs = [0, 1]
+    frames_with_list = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
     assert frames_with_list.shape == (2, image_size[0], image_size[1])
 
     frame_idxs = np.array([0, 1])
     frames_with_array = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
-    assert frames_with_list.shape == (2, image_size[0], image_size[1])
+    assert frames_with_array.shape == (2, image_size[0], image_size[1])
 
 
 def check_imaging_return_types(img_ex: ImagingExtractor):

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -205,6 +205,32 @@ def check_imaging_equal(imaging_extractor1: ImagingExtractor, imaging_extractor2
     )
 
 
+def assert_get_frames_function_return_shapes(imaging_extractor: ImagingExtractor):
+    """Utiliy to check whether an ImagingExtractor get_frames function behaves as expected. We aim for the function to
+    behave as numpy slicing and indexing as much as possible
+
+    Parameters
+    ----------
+    imaging_extractor : ImagingExtractor
+    An image extractor
+    """
+
+    image_size = imaging_extractor.get_image_size()
+    frames_with_scalar = imaging_extractor.get_frames(0, channel=0)
+
+    assert frames_with_scalar.shape == image_size
+
+    frames_with_single_element_list = imaging_extractor.get_frames([0], channel=0)
+    assert frames_with_single_element_list.shape == (1, image_size[0], image_size[1])
+
+    frames_with_list = imaging_extractor.get_frames([0, 1], channel=0)
+    assert frames_with_list.shape == (2, image_size[0], image_size[1])
+
+    frame_idxs = np.array([0, 1])
+    frames_with_array = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
+    assert frames_with_list.shape == (2, image_size[0], image_size[1])
+
+
 def check_imaging_return_types(img_ex: ImagingExtractor):
     """
     Parameters

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -319,19 +319,22 @@ def assert_get_frames_return_shape(imaging_extractor: ImagingExtractor):
 
     frame_idxs = 0
     frames_with_scalar = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
-    assert frames_with_scalar.shape == image_size
+    assert frames_with_scalar.shape == image_size, "get_frames does not work correctly with frame_idxs=0"
 
     frame_idxs = [0]
     frames_with_single_element_list = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
-    assert frames_with_single_element_list.shape == (1, image_size[0], image_size[1])
+    assert_msg = "get_frames does not work correctly with frame_idxs=[0]"
+    assert frames_with_single_element_list.shape == (1, image_size[0], image_size[1]), assert_msg
 
     frame_idxs = [0, 1]
     frames_with_list = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
-    assert frames_with_list.shape == (2, image_size[0], image_size[1])
+    assert_msg = "get_frames does not work correctly with frame_idxs=[0, 1]"
+    assert frames_with_list.shape == (2, image_size[0], image_size[1]), assert_msg
 
     frame_idxs = np.array([0, 1])
     frames_with_array = imaging_extractor.get_frames(frame_idxs=frame_idxs, channel=0)
-    assert frames_with_array.shape == (2, image_size[0], image_size[1])
+    assert_msg = "get_frames does not work correctly with frame_idxs=np.arrray([0, 1])"
+    assert frames_with_array.shape == (2, image_size[0], image_size[1]), assert_msg
 
 
 def check_imaging_return_types(img_ex: ImagingExtractor):

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -205,7 +205,7 @@ def check_imaging_equal(imaging_extractor1: ImagingExtractor, imaging_extractor2
     )
 
 
-def assert_get_frames_indexing_with_single_channel(imaging_extractor: ImagingExtractor):
+def assert_get_frames_return_shape(imaging_extractor: ImagingExtractor):
     """Utiliy to check whether an ImagingExtractor get_frames function behaves as expected. We aim for the function to
     behave as numpy slicing and indexing as much as possible
 

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -5,13 +5,11 @@ from pathlib import Path
 
 import numpy as np
 
-from pynwb import NWBFile, TimeSeries, NWBHDF5IO
-from pynwb.image import ImageSeries
-from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation
+from pynwb import NWBFile, NWBHDF5IO
+from pynwb.ophys import TwoPhotonSeries, OpticalChannel
 
 from roiextractors import NwbImagingExtractor
-from roiextractors.testing import generate_dummy_video, assert_get_frames_indexing_with_single_channel
-from roiextractors.extraction_tools import PathType, ArrayType
+from roiextractors.testing import generate_dummy_video, assert_get_frames_return_shape
 
 
 class TestNwbImagingExtractor(unittest.TestCase):
@@ -112,7 +110,7 @@ class TestNwbImagingExtractor(unittest.TestCase):
     def test_get_frames_indexing_with_single_channel(self):
 
         nwb_imaging_extractor = NwbImagingExtractor(file_path=self.file_path)
-        assert_get_frames_indexing_with_single_channel(imaging_extractor=nwb_imaging_extractor)
+        assert_get_frames_return_shape(imaging_extractor=nwb_imaging_extractor)
 
 
 if __name__ == "__main__":

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -10,7 +10,7 @@ from pynwb.image import ImageSeries
 from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation
 
 from roiextractors import NwbImagingExtractor
-from roiextractors.testing import generate_dummy_video
+from roiextractors.testing import generate_dummy_video, assert_get_frames_indexing_with_single_channel
 from roiextractors.extraction_tools import PathType, ArrayType
 
 
@@ -108,6 +108,11 @@ class TestNwbImagingExtractor(unittest.TestCase):
         expected_video = self.video
 
         np.testing.assert_array_almost_equal(video, expected_video)
+
+    def test_get_frames_indexing_with_single_channel(self):
+
+        nwb_imaging_extractor = NwbImagingExtractor(file_path=self.file_path)
+        assert_get_frames_indexing_with_single_channel(imaging_extractor=nwb_imaging_extractor)
 
 
 if __name__ == "__main__":

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -86,14 +86,26 @@ class TestExtractors(TestCase):
             return
 
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
-    def test_get_frames_shape(self, extractor_class, extractor_kwargs):
+    def test_imaging_extractors_canonical_shape(self, extractor_class, extractor_kwargs):
+        """Test that get_video and get_frame methods for their shapes and types under different indexing scenarios"""
         extractor = extractor_class(**extractor_kwargs)
-        assert_get_frames_return_shape(imaging_extractor=extractor)
+        image_size = extractor.get_image_size()
+        num_channels = extractor.get_num_channels()
+
+        # Test canonical shape for get video
+        video = extractor.get_video()
+        canonical_video_shape = [extractor.get_num_frames(), image_size[0], image_size[1]]
+        if num_channels > 1:
+            canonical_video_shape.append(num_channels)
+        assert video.shape == tuple(canonical_video_shape)
 
         # Test spikeinterface-like behavior
         one_element_video_shape = extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
         expected_shape = (1, image_size[0], image_size[1])
         assert one_element_video_shape == expected_shape
+
+        # Test frames behavior
+        assert_get_frames_return_shape(imaging_extractor=extractor)
 
     segmentation_extractor_list = [
         param(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,7 +19,7 @@ from roiextractors import (
 from roiextractors.testing import (
     check_imaging_equal,
     check_segmentations_equal,
-    assert_get_frames_function_return_shapes,
+    assert_get_frames_indexing_with_single_channel,
 )
 
 from .setup_paths import OPHYS_DATA_PATH, OUTPUT_PATH
@@ -68,7 +68,7 @@ class TestExtractors(TestCase):
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
     def test_imaging_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
-        assert_get_frames_function_return_shapes(imaging_extractor=extractor)
+        assert_get_frames_indexing_with_single_channel(imaging_extractor=extractor)
 
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,7 +19,7 @@ from roiextractors import (
 from roiextractors.testing import (
     check_imaging_equal,
     check_segmentations_equal,
-    assert_get_frames_indexing_with_single_channel,
+    assert_get_frames_return_shape,
 )
 
 from .setup_paths import OPHYS_DATA_PATH, OUTPUT_PATH
@@ -68,7 +68,6 @@ class TestExtractors(TestCase):
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
     def test_imaging_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
-        assert_get_frames_indexing_with_single_channel(imaging_extractor=extractor)
 
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix
@@ -83,16 +82,9 @@ class TestExtractors(TestCase):
             return
 
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
-    def test_imaging_extractors_canonical_shape(self, extractor_class, extractor_kwargs):
+    def test_get_frames_shape(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
-        image_size = extractor.get_image_size()
-        num_channels = extractor.get_num_channels()
-        video = extractor.get_video()
-
-        canonical_video_shape = [extractor.get_num_frames(), image_size[0], image_size[1]]
-        if num_channels > 1:
-            canonical_video_shape.append(num_channels)
-        assert video.shape == tuple(canonical_video_shape)
+        assert_get_frames_return_shape(imaging_extractor=extractor)
 
     segmentation_extractor_list = [
         param(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,7 +16,11 @@ from roiextractors import (
     Suite2pSegmentationExtractor,
     CnmfeSegmentationExtractor,
 )
-from roiextractors.testing import check_imaging_equal, check_segmentations_equal
+from roiextractors.testing import (
+    check_imaging_equal,
+    check_segmentations_equal,
+    assert_get_frames_function_return_shapes,
+)
 
 from .setup_paths import OPHYS_DATA_PATH, OUTPUT_PATH
 
@@ -64,6 +68,8 @@ class TestExtractors(TestCase):
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
     def test_imaging_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
+        assert_get_frames_function_return_shapes(imaging_extractor=extractor)
+
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix
             output_path = self.savedir / f"{extractor_class.__name__}{suffix}"

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -8,7 +8,7 @@ import numpy as np
 from parameterized import parameterized, param
 
 from roiextractors.extraction_tools import VideoStructure
-from roiextractors.testing import check_imaging_equal, assert_get_frames_indexing_with_single_channel
+from roiextractors.testing import check_imaging_equal, assert_get_frames_return_shape
 from roiextractors import NumpyMemmapImagingExtractor
 
 
@@ -145,7 +145,7 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
             file_path=file_path, video_structure=video_structure, sampling_frequency=1, dtype=dtype, offset=self.offset
         )
 
-        assert_get_frames_indexing_with_single_channel(imaging_extractor=extractor)
+        assert_get_frames_return_shape(imaging_extractor=extractor)
 
 
 if __name__ == "__main__":

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -8,7 +8,7 @@ import numpy as np
 from parameterized import parameterized, param
 
 from roiextractors.extraction_tools import VideoStructure
-from roiextractors.testing import check_imaging_equal
+from roiextractors.testing import check_imaging_equal, assert_get_frames_indexing_with_single_channel
 from roiextractors import NumpyMemmapImagingExtractor
 
 
@@ -107,6 +107,45 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
             offset=self.offset,
         )
         check_imaging_equal(imaging_extractor1=extractor, imaging_extractor2=roundtrip_extractor)
+
+    def test_get_frames_indexing_with_single_channel(self):
+        # Build a video structure
+        num_rows = 10
+        num_columns = 20
+        num_channels = 1
+        frame_axis = 0
+        rows_axis = 1
+        columns_axis = 2
+        channels_axis = 3
+        dtype = "uint16"
+
+        video_structure = VideoStructure(
+            num_rows=num_rows,
+            num_columns=num_columns,
+            num_channels=num_channels,
+            rows_axis=rows_axis,
+            columns_axis=columns_axis,
+            channels_axis=channels_axis,
+            frame_axis=frame_axis,
+        )
+
+        # Build a random video
+        memmap_shape = video_structure.build_video_shape(self.num_frames)
+        random_video = np.random.randint(low=0, high=256, size=memmap_shape).astype(dtype)
+
+        # Save it to memory
+        file_path = self.write_directory / f"video_test_shapes.dat"
+        file = np.memmap(file_path, dtype=dtype, mode="w+", shape=memmap_shape)
+        file[:] = random_video[:]
+        file.flush()
+        del file
+
+        # Load the video with the extactor
+        extractor = NumpyMemmapImagingExtractor(
+            file_path=file_path, video_structure=video_structure, sampling_frequency=1, dtype=dtype, offset=self.offset
+        )
+
+        assert_get_frames_indexing_with_single_channel(imaging_extractor=extractor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As described in #147 we decided to mimic the behavior of numpy. This PR introduces corresponding tests for all the imaging extractors for which we test with data (plus memmap and nwb imaging extractor) and modifies the behavior to obtain the desired behavior. 