### PR TITLE
MultiImagingExtractor remove decorator from `get_frames`

### DIFF
--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -68,8 +68,9 @@ class MultiImagingExtractor(ImagingExtractor):
 
         return times
 
-    @check_get_frames_args
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> NumpyArray:
+        frame_idxs = np.array(frame_idxs)
+        assert np.all(frame_idxs < self.get_num_frames()), "'frame_idxs' exceed number of frames"
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")
         relative_frame_indices = frame_idxs - np.array(self._start_frames)[extractor_indices]
         # Match frame_idxs to imaging extractors


### PR DESCRIPTION
The `check_get_frames_args` decorator is problematic when frames are returned from the data generator:
https://github.com/catalystneuro/nwb-conversion-tools/blob/07e958d7564eb12d00a5ff5fabe661677d023efa/src/nwb_conversion_tools/tools/roiextractors/roiextractors.py#L188
because when a single frame is retrieved the decorator returns only the first dimension of the frame:
https://github.com/catalystneuro/roiextractors/blob/8db5f9cb3a7ee5efee49b7fd0b694c7a8105519a/src/roiextractors/extraction_tools.py#L298-L299

This solution removes this decorator from being used in the `MultiImagingExtractor`. 