### PR TITLE
Add `folder_path` as an argument for `Suite2pSegmentationExtractor`

### DIFF
--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -41,12 +41,12 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
         from warnings import warn
 
         if file_path is not None:
-            warning_stiring = (
-                "The keyword argument 'file_path' is being deprecated in favour of 'folder_path', "
-                "'folder_path' takes precence over 'file_path'"
+            warning_string = (
+                "The keyword argument 'file_path' is being deprecated on or after August, 2022 in favor of 'folder_path'. "
+                "'folder_path' takes precence over 'file_path'."
             )
             warn(
-                message=warning_stiring,
+                message=warning_string,
                 category=DeprecationWarning,
             )
             folder_path = file_path if folder_path is None else folder_path

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -119,10 +119,11 @@ class TestExtractors(TestCase):
         ),
         param(
             extractor_class=Suite2pSegmentationExtractor,
-            extractor_kwargs=dict(
-                # TODO: argument name is 'file_path' on roiextractors, but it clearly refers to a folder_path
-                file_path=str(OPHYS_DATA_PATH / "segmentation_datasets" / "suite2p")
-            ),
+            extractor_kwargs=dict(folder_path=str(OPHYS_DATA_PATH / "segmentation_datasets" / "suite2p")),
+        ),
+        param(
+            extractor_class=Suite2pSegmentationExtractor,
+            extractor_kwargs=dict(file_path=str(OPHYS_DATA_PATH / "segmentation_datasets" / "suite2p")),
         ),
     ]
 
@@ -130,8 +131,15 @@ class TestExtractors(TestCase):
     def test_segmentation_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
         try:
-            suffix = Path(extractor_kwargs["file_path"]).suffix
-            output_path = self.savedir / f"{extractor_class.__name__}{suffix}"
+            roundtrip_kwargs = copy(extractor_kwargs)
+            if "folder_path" in extractor_kwargs:
+                output_path = self.savedir / f"{extractor_class.__name__}"
+                roundtrip_kwargs.update(folder_path=output_path)
+
+            elif "file_path" in extractor_kwargs:
+                suffix = Path(extractor_kwargs["file_path"]).suffix
+                output_path = self.savedir / f"{extractor_class.__name__}{suffix}"
+                roundtrip_kwargs.update(file_path=output_path)
 
             # TODO:  ExtractSegmentation
             extractors_not_ready = [
@@ -140,9 +148,6 @@ class TestExtractors(TestCase):
 
             if extractor_class.__name__ not in extractors_not_ready:
                 extractor_class.write_segmentation(extractor, output_path)
-
-                roundtrip_kwargs = copy(extractor_kwargs)
-                roundtrip_kwargs.update(file_path=output_path)
                 roundtrip_extractor = extractor_class(**roundtrip_kwargs)
                 check_segmentations_equal(
                     segmentation_extractor1=extractor, segmentation_extractor2=roundtrip_extractor


### PR DESCRIPTION
Right now in master the `Suite2pSegmentationExtractor` takes `file_path` as one of its arguments but a `folder_path` is passed instead. This PR adds the possibility for using `file_path` while keeping the possibility of using `file_path` for backwards compatibility. A deprecation warning is now issued with no specific date (any ideas?). The tests are also modfied to take this into account and now there are two tests for `Suit2P` data (supporting the old and the new arguments).

Other minor things:
Removed some os.path utilities in favour of pathlib.
The `write_segmentation` method is moved to the bottom of the code to comply with the standard of code organization that we have in other extractors. 