### PR TITLE
Test that sampling rate is float 

### DIFF
--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -51,7 +51,7 @@ class Hdf5ImagingExtractor(ImagingExtractor):
             self._video = DatasetView(self._file[self._mov_field])
             if sampling_frequency is None:
                 assert "fr" in self._video.attrs, "sampling frequency information is unavailable!"
-                self._sampling_frequency = self._video.attrs["fr"]
+                self._sampling_frequency = float(self._video.attrs["fr"])
             else:
                 self._sampling_frequency = sampling_frequency
         else:

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -69,7 +69,7 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
 
         self.file_path = Path(file_path)
         self.video_structure = video_structure
-        self._sampling_frequency = sampling_frequency
+        self._sampling_frequency = float(sampling_frequency)
         self.offset = offset
         self.dtype = dtype
 

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -7,15 +7,12 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from .segmentationextractor import SegmentationExtractor
 from .imagingextractor import ImagingExtractor
 
+from roiextractors import NumpyImagingExtractor
+from roiextractors.extraction_tools import DtypeType
+
 NoneType = type(None)
 floattype = (float, np.floating)
 inttype = (int, np.integer)
-
-
-import numpy as np
-
-from roiextractors import NumpyImagingExtractor
-from roiextractors.extraction_tools import DtypeType
 
 
 def generate_dummy_video(size: Tuple[int], dtype: DtypeType = "uint16"):
@@ -188,8 +185,6 @@ def check_segmentation_return_types(seg: SegmentationExtractor):
 
 
 def check_imaging_equal(imaging_extractor1: ImagingExtractor, imaging_extractor2: ImagingExtractor):
-    check_imaging_return_types(imaging_extractor1)
-    check_imaging_return_types(imaging_extractor2)
     # assert equality:
     assert imaging_extractor1.get_num_frames() == imaging_extractor2.get_num_frames()
     assert imaging_extractor1.get_num_channels() == imaging_extractor2.get_num_channels()
@@ -242,7 +237,7 @@ def check_imaging_return_types(img_ex: ImagingExtractor):
     """
     assert isinstance(img_ex.get_num_frames(), inttype)
     assert isinstance(img_ex.get_num_channels(), inttype)
-    assert isinstance(img_ex.get_sampling_frequency(), (NoneType, floattype, inttype))
+    assert isinstance(img_ex.get_sampling_frequency(), floattype)
     _assert_iterable_complete(
         iterable=img_ex.get_channel_names(),
         dtypes=(list, NoneType),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,6 @@ from copy import copy
 
 from parameterized import parameterized, param
 from hdmf.testing import TestCase
-from numpy.testing import assert_array_equal
 
 from roiextractors import (
     TiffImagingExtractor,
@@ -16,7 +15,7 @@ from roiextractors import (
     Suite2pSegmentationExtractor,
     CnmfeSegmentationExtractor,
 )
-from roiextractors.testing import check_imaging_equal, check_segmentations_equal
+from roiextractors.testing import check_imaging_equal, check_segmentations_equal, check_imaging_return_types
 
 from .setup_paths import OPHYS_DATA_PATH, OUTPUT_PATH
 
@@ -64,6 +63,8 @@ class TestExtractors(TestCase):
     @parameterized.expand(imaging_extractor_list, name_func=custom_name_func)
     def test_imaging_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
+        check_imaging_return_types(extractor)
+
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix
             output_path = self.savedir / f"{extractor_class.__name__}{suffix}"
@@ -73,6 +74,8 @@ class TestExtractors(TestCase):
             roundtrip_kwargs.update(file_path=output_path)
             roundtrip_extractor = extractor_class(**roundtrip_kwargs)
             check_imaging_equal(imaging_extractor1=extractor, imaging_extractor2=roundtrip_extractor)
+            check_imaging_return_types(roundtrip_extractor)
+
         except NotImplementedError:
             return
 
@@ -129,6 +132,7 @@ class TestExtractors(TestCase):
     @parameterized.expand(segmentation_extractor_list, name_func=custom_name_func)
     def test_segmentation_extractors(self, extractor_class, extractor_kwargs):
         extractor = extractor_class(**extractor_kwargs)
+
         try:
             suffix = Path(extractor_kwargs["file_path"]).suffix
             output_path = self.savedir / f"{extractor_class.__name__}{suffix}"


### PR DESCRIPTION
We have a function called `check_imaging_equal` that is doing a typing test `check_imaging_return_types` that only apply to each of the compared imaging extractors separately. This PR breaks that apart and ensures that the `check_imaging_return_types` function checks for sampling rate being float. 