### PR TITLE
Fix `get_dtype` for `NumpyImagingExtractor`

### DIFF
--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -62,7 +62,7 @@ class ImagingExtractor(ABC, BaseExtractor):
         pass
 
     def get_dtype(self) -> DtypeType:
-        return self.get_frames(0, 0).dtype
+        return self.get_frames(frame_idxs=[0], channel=0).dtype
 
     @check_get_videos_args
     def get_video(

--- a/tests/test_internals/test_frame_slice_imaging.py
+++ b/tests/test_internals/test_frame_slice_imaging.py
@@ -63,6 +63,9 @@ class TestFrameSliceImaging(TestCase):
             self.toy_imaging_example.get_frames(frame_idxs=[4, 6]),
         )
 
+    def test_get_dtype(self):
+        assert self.frame_sliced_imaging.get_dtype() == self.toy_imaging_example.get_dtype()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`NumpyImagingExtractor.get_dtype()` fails when it tries to retrieve the data type of a single frame using an integer as frame index: 
`self.get_frames(0, 0).dtype`, it should be changed to an ArrayType. 
This PR might be connected to an existing issue #147 
I haven't seen a fix for this (do let me know if there was), neither a unittest for get_dtype.
