### PR TITLE
Synch setup installation methods with nwb conversion tools

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test full installation
         run: pip install .[full]
       - name: Install testing requirements (-e needed for codecov report)
-        run: pip install -e .[testing]
+        run: pip install -e .[test]
 
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(root / "requirements-full.txt") as f:
 testing_dependencies = copy(full_dependencies)
 with open(root / "requirements-testing.txt") as f:
     testing_dependencies.extend(f.readlines())
-extras_require = dict(full=full_dependencies, testing=testing_dependencies)
+extras_require = dict(full=full_dependencies, test=testing_dependencies)
 
 # Create a local copy for the gin test configuration file based on the master file `base_gin_test_config.json`
 gin_config_file_base = root / "base_gin_test_config.json"


### PR DESCRIPTION
Small PR so we have consistent naming conventions for installing with extra requirements. Changed `testing` to `test`.