### PR TITLE
Add dummy segmentation extractor 

### DIFF
--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -74,7 +74,7 @@ class NumpyImagingExtractor(ImagingExtractor):
 
         frames = self._video.take(indices=frame_idxs, axis=0)
         if channel is not None:
-            frames = frames[:, :, :, channel].squeeze()
+            frames = frames[..., channel].squeeze()
 
         return frames
 
@@ -178,7 +178,7 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             list of ROI ids that are rejected manually or via automated rejection
         channel_names: list
             list of strings representing channel names
-        movie_dims: list
+        movie_dims: tuple
             height x width of the movie
         """
         SegmentationExtractor.__init__(self)
@@ -222,7 +222,7 @@ class NumpySegmentationExtractor(SegmentationExtractor):
                 raise ValueError("'timeeseries' is does not exist")
         elif isinstance(image_masks, np.ndarray):
             NoneType = type(None)
-            assert isinstance(raw, np.ndarray)
+            assert isinstance(raw, (np.ndarray, NoneType))
             assert isinstance(dff, (np.ndarray, NoneType))
             assert isinstance(neuropil, (np.ndarray, NoneType))
             assert isinstance(deconvolved, (np.ndarray, NoneType))

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -104,8 +104,8 @@ class SegmentationExtractor(ABC, BaseExtractor):
 
         Returns
         -------
-        channel_ids: list
-            Channel list.
+        roi_ids: list
+            List of roi ids.
         """
         pass
 

--- a/tests/test_internals/test_testing_tools.py
+++ b/tests/test_internals/test_testing_tools.py
@@ -1,0 +1,72 @@
+import unittest
+
+from roiextractors.testing import generate_dummy_segmentation_extractor
+
+
+class TestDummySegmentationExtractor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.num_rois = 10
+        self.num_frames = 30
+        self.num_rows = 25
+        self.num_columns = 25
+        self.sampling_frequency = 30.0
+
+        self.raw = True
+        self.dff = True
+        self.deconvolved = True
+        self.neuropil = True
+
+    def test_default_values(self):
+        segmentation_extractor = generate_dummy_segmentation_extractor()
+
+        # Test basic shape
+        assert segmentation_extractor.get_num_rois() == self.num_rois
+        assert segmentation_extractor.get_num_frames() == self.num_frames
+        assert segmentation_extractor.get_image_size() == (self.num_rows, self.num_columns)
+        assert segmentation_extractor.get_sampling_frequency() == self.sampling_frequency
+        assert segmentation_extractor.get_roi_ids() == list(range(self.num_rois))
+        assert segmentation_extractor.get_accepted_list() == segmentation_extractor.get_roi_ids()
+        assert segmentation_extractor.get_rejected_list() == []
+        assert segmentation_extractor.get_roi_locations().shape == (2, self.num_rois)
+
+        # Test image masks
+        assert segmentation_extractor.get_roi_image_masks().shape == (self.num_rows, self.num_columns, self.num_rois)
+        # TO-DO Missing testing of pixel masks
+
+        # Test summary images
+        assert segmentation_extractor.get_image(name="mean").shape == (self.num_rows, self.num_columns)
+        assert segmentation_extractor.get_image(name="correlation").shape == (self.num_rows, self.num_columns)
+
+        # Test signals
+        assert segmentation_extractor.get_traces(name="raw").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="dff").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="deconvolved").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="neuropil").shape == (self.num_rois, self.num_frames)
+
+    def test_passing_parameters(self):
+
+        segmentation_extractor = generate_dummy_segmentation_extractor()
+
+        # Test basic shape
+        assert segmentation_extractor.get_num_rois() == self.num_rois
+        assert segmentation_extractor.get_num_frames() == self.num_frames
+        assert segmentation_extractor.get_image_size() == (self.num_rows, self.num_columns)
+        assert segmentation_extractor.get_sampling_frequency() == self.sampling_frequency
+        assert segmentation_extractor.get_roi_ids() == list(range(self.num_rois))
+        assert segmentation_extractor.get_accepted_list() == segmentation_extractor.get_roi_ids()
+        assert segmentation_extractor.get_rejected_list() == []
+        assert segmentation_extractor.get_roi_locations().shape == (2, self.num_rois)
+
+        # Test image masks
+        assert segmentation_extractor.get_roi_image_masks().shape == (self.num_rows, self.num_columns, self.num_rois)
+        # TO-DO Missing testing of pixel masks
+
+        # Test summary images
+        assert segmentation_extractor.get_image(name="mean").shape == (self.num_rows, self.num_columns)
+        assert segmentation_extractor.get_image(name="correlation").shape == (self.num_rows, self.num_columns)
+
+        # Test signals
+        assert segmentation_extractor.get_traces(name="raw").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="dff").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="deconvolved").shape == (self.num_rois, self.num_frames)
+        assert segmentation_extractor.get_traces(name="neuropil").shape == (self.num_rois, self.num_frames)


### PR DESCRIPTION
I am adding this as a general testing tool that will help us with the testing and refactoring of the segmentation interfaces in nwb conversion tools.  The code is documented and has a simple test with it.

I also changed other small mistakes, errors in the code such as wrong documentation in the base class and inconsistent typing requirements in the `NumpySegmentationExtractor`