### PR TITLE
Make get video an abstract method in `ImagingExtractor`

### DIFF
--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -103,6 +103,9 @@ class Hdf5ImagingExtractor(ImagingExtractor):
         frames = self._video.lazy_slice[slice_start:slice_stop, :, :, channel].dsetread()
         return frames
 
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        return self._video.lazy_slice[start_frame:end_frame, :, :, channel].dsetread()
+
     def get_image_size(self) -> Tuple[int, int]:
         return (self._num_rows, self._num_cols)
 

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -78,6 +78,10 @@ class NumpyImagingExtractor(ImagingExtractor):
 
         return frames
 
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+
+        return self._video[start_frame:end_frame, ..., channel]
+
     def get_image_size(self) -> Tuple[int, int]:
         return (self._num_rows, self._num_columns)
 

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -166,10 +166,12 @@ class NwbImagingExtractor(ImagingExtractor):
             frames = frames.squeeze()
         return frames
 
-    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0):
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
         start_frame = start_frame if start_frame is not None else 0
         end_frame = end_frame if end_frame is not None else self.get_num_frames()
-        video = self.get_frames(frame_idxs=range(start_frame, end_frame), channel=channel)
+
+        video = self.two_photon_series.data
+        video = video[start_frame:end_frame].transpose([0, 2, 1])
         return video
 
     def get_image_size(self):

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -147,6 +147,11 @@ class SbxImagingExtractor(ImagingExtractor):
         frame_out = np.stack(frames_list, axis=2).T.squeeze()
         return np.iinfo("uint16").max - frame_out
 
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+
+        frame_out = np.iinfo("uint16").max - self._data[channel, :, :, 0, start_frame:end_frame]
+        return frame_out.transpose(2, 1, 0)
+
     def get_image_size(self) -> Tuple[int, int]:
         return tuple(self._info["sz"])
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -92,6 +92,10 @@ class ScanImageTiffImagingExtractor(ImagingExtractor):
         with ScanImageTiffReader(str(self.file_path)) as io:
             return io.data(beg=idx, end=idx + 1)
 
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        with ScanImageTiffReader(filename=str(self.file_path)) as io:
+            return io.data(beg=start_frame, end=end_frame)
+
     def get_image_size(self) -> Tuple[int, int]:
         return (self._num_rows, self._num_columns)
 

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 from warnings import warn
 
 import numpy as np
@@ -70,6 +71,9 @@ class TiffImagingExtractor(ImagingExtractor):
     @check_get_frames_args
     def get_frames(self, frame_idxs, channel: int = 0):
         return self._video[frame_idxs, ...]
+
+    def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        return self._video[start_frame:end_frame, ...]
 
     def get_image_size(self) -> Tuple[int, int]:
         return (self._num_rows, self._num_columns)

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -91,6 +91,15 @@ class MultiImagingExtractor(ImagingExtractor):
         frames = np.concatenate(frames_to_concatenate, axis=0).squeeze()
         return frames
 
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        # To-do: implement this without reference to get_frames
+        start = start_frame if start_frame is not None else 0
+        stop = end_frame if end_frame is not None else self.get_num_frames()
+        frame_idxs = range(start, stop)
+        return self.get_frames(frame_idxs=frame_idxs, channel=channel)
+
     def _get_frames_from_an_imaging_extractor(self, extractor_index: int, frame_idxs: ArrayType) -> NumpyArray:
         imaging_extractor = self._imaging_extractors[extractor_index]
         frames = imaging_extractor.get_frames(frame_idxs=frame_idxs)

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -296,7 +296,8 @@ def check_imaging_equal(
         assert_array_equal(imaging_extractor1.get_channel_names(), imaging_extractor2.get_channel_names())
 
     assert_array_equal(
-        imaging_extractor1.get_frames(frame_idxs=[0, 1]), imaging_extractor2.get_frames(frame_idxs=[0, 1])
+        imaging_extractor1.get_video(start_frame=0, end_frame=1),
+        imaging_extractor2.get_video(start_frame=0, end_frame=1),
     )
     assert_array_almost_equal(
         imaging_extractor1.frame_to_time(np.arange(imaging_extractor1.get_num_frames())),


### PR DESCRIPTION
We have been discussed how to standardize the way in which the imaging extractors extract the data from the different formats: https://github.com/catalystneuro/roiextractors/issues/155

We took the decision that imaging extractors objects should implement `get_video` which has slicing semantics by default and that get frames should be either implemented on top of this or as a separate method. Consequently, this PR makes `get_video` an abstract method -forcing implementation on imaging extractor objects that inherit from the base class- and remove the abstract object decorator from `get_frames`. 

For the tests to pass this PR also required implementing versions of `get_video` in most of the imaging extractor classes. Most of them are fine but `MultiImagingExtractor` is implemented on terms of the already implemented  `get_frames` as is more complicated. I will come back to this. Also I modified the general imaging extractor comparison function to compare the outputs `get_video` instead of `get_frames` between to imaging extractors as this is our primary output method now. 
 