### PR TITLE
Test spikeinterface-like behavior for get_video with one element

### DIFF
--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -84,6 +84,7 @@ class TestNwbImagingExtractor(unittest.TestCase):
         assert num_frames == expected_num_frames
         assert num_channels == expected_num_channels
 
+        # Test numpy like behavior for frame_idxs
         frame_idxs = 0
         frames_with_scalar = nwb_imaging_extractor.get_frames(frame_idxs)
         expected_frames = self.video[frame_idxs, ...]
@@ -103,6 +104,11 @@ class TestNwbImagingExtractor(unittest.TestCase):
         frames_with_array = nwb_imaging_extractor.get_frames(frame_idxs)
         expected_frames = self.video[frame_idxs, ...]
         np.testing.assert_array_almost_equal(frames_with_array, expected_frames)
+
+        # Test spikeinterface-like behavior for get_video
+        one_element_video_shape = nwb_imaging_extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
+        expected_shape = (1, image_size[0], image_size[1])
+        assert one_element_video_shape == expected_shape
 
         video = nwb_imaging_extractor.get_video()
         expected_video = self.video

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -91,6 +91,11 @@ class TestExtractors(TestCase):
             canonical_video_shape.append(num_channels)
         assert video.shape == tuple(canonical_video_shape)
 
+        # Test spikeinterface-like behavior
+        one_element_video_shape = extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
+        expected_shape = (1, image_size[0], image_size[1])
+        assert one_element_video_shape == expected_shape
+
     segmentation_extractor_list = [
         param(
             extractor_class=CaimanSegmentationExtractor,

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -147,6 +147,10 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
 
         assert_get_frames_indexing_with_single_channel(imaging_extractor=extractor)
 
+        one_element_video_shape = extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
+        expected_shape = (1, num_rows, num_columns)
+        assert one_element_video_shape == expected_shape
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is something important for the chunk iterator that is being developed by @weiglszonja. Note that this should be merged after #180 as it has it as a base. 