### PR TITLE
Remove squeezing frames in get_frames for `MultiImagingExtractor`

### DIFF
--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -68,8 +68,11 @@ class MultiImagingExtractor(ImagingExtractor):
 
         return times
 
-    @check_get_frames_args
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> NumpyArray:
+        if isinstance(frame_idxs, (int, np.integer)):
+            frame_idxs = [frame_idxs]
+        frame_idxs = np.array(frame_idxs)
+        assert np.all(frame_idxs < self.get_num_frames()), "'frame_idxs' exceed number of frames"
         extractor_indices = np.searchsorted(self._end_frames, frame_idxs, side="right")
         relative_frame_indices = frame_idxs - np.array(self._start_frames)[extractor_indices]
         # Match frame_idxs to imaging extractors

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -88,7 +88,7 @@ class MultiImagingExtractor(ImagingExtractor):
                 frames_for_each_extractor = frames_for_each_extractor[np.newaxis, ...]
             frames_to_concatenate.append(frames_for_each_extractor)
 
-        frames = np.concatenate(frames_to_concatenate, axis=0).squeeze()
+        frames = np.concatenate(frames_to_concatenate, axis=0)
         return frames
 
     def get_video(

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -21,6 +21,7 @@ class TestMultiImagingExtractor(TestCase):
         cls.multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=cls.extractors)
 
     def test_get_image_size(self):
+        #assert_get_frames_return_shape(self.multi_imaging_extractor)
         assert self.multi_imaging_extractor.get_image_size() == self.extractors[0].get_image_size()
 
     def test_get_num_frames(self):
@@ -78,6 +79,12 @@ class TestMultiImagingExtractor(TestCase):
             [self.extractors[i].get_video() for i in range(3)],
             axis=0,
         )
+        assert_array_equal(test_frames, expected_frames)
+
+    def test_get_get_video_single_frame(self):
+        test_frames = self.multi_imaging_extractor.get_video(start_frame=10, end_frame=11)
+        expected_frames = self.extractors[1].get_video(start_frame=0, end_frame=1)
+
         assert_array_equal(test_frames, expected_frames)
 
     def test_set_incorrect_times(self):

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -21,7 +21,6 @@ class TestMultiImagingExtractor(TestCase):
         cls.multi_imaging_extractor = MultiImagingExtractor(imaging_extractors=cls.extractors)
 
     def test_get_image_size(self):
-        #assert_get_frames_return_shape(self.multi_imaging_extractor)
         assert self.multi_imaging_extractor.get_image_size() == self.extractors[0].get_image_size()
 
     def test_get_num_frames(self):

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -80,7 +80,7 @@ class TestMultiImagingExtractor(TestCase):
         )
         assert_array_equal(test_frames, expected_frames)
 
-    def test_get_get_video_single_frame(self):
+    def test_get_video_single_frame(self):
         test_frames = self.multi_imaging_extractor.get_video(start_frame=10, end_frame=11)
         expected_frames = self.extractors[1].get_video(start_frame=0, end_frame=1)
 


### PR DESCRIPTION
`MultiImagingExtractor` `get_video` calls through `get_frames` to handle iterating over frames from multiple ImagingExtractors. [This condition](https://github.com/catalystneuro/neuroconv/pull/54/commits/11795cff09a250d8bb9d4a000f19314681482d39) in catalystneuro/neuroconv#54 was necessary because it can happen that for one of the extractors a single frame is returned, so in order to remove it, we have to make sure that frames are not squeezed in `MultiImagingExtractor` and the `get_video` returns the frames correctly. 

This PR removes squeezing the frames in `MultiImagingExtractor` and adds a test for `get_video`. 

Resolve #161
