### PR TITLE
`SegmentationExtractor`: add frame_to_time, get_roi_ids as class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Improvements
+* Add `frame_to_time` to `SegmentationExtractor`, `get_roi_ids` is now a class method. [PR #187](https://github.com/catalystneuro/roiextractors/pull/187)
 
 ### Fixes
 

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -159,9 +159,5 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
             params.create_dataset("data/dims", data=segmentation_object.get_image_size())
             f.create_dataset("dims", data=segmentation_object.get_image_size())
 
-    # defining the abstract class enformed methods:
-    def get_roi_ids(self):
-        return list(range(self.get_num_rois()))
-
     def get_image_size(self):
         return self._dataset_file["params"]["data"]["dims"][()]

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -306,7 +306,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
                         self._accepted_list = ps["Accepted"].data[:]
                     if "Rejected" in ps.colnames:
                         self._rejected_list = ps["Rejected"].data[:]
-                    self._roi_idx = np.array(ps.id.data)
                 else:
                     raise Exception("could not find any PlaneSegmentation in nwbfile")
             # Extracting stores images as GrayscaleImages:
@@ -340,9 +339,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
     def roi_locations(self):
         if self._roi_locs is not None:
             return self._roi_locs.data[:].T
-
-    def get_roi_ids(self):
-        return list(self._roi_idx)
 
     def get_image_size(self):
         return self._image_masks.shape[:2]

--- a/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -138,9 +138,5 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
             if segmentation_object.get_sampling_frequency() is not None:
                 inputoptions.create_dataset("Fs", data=segmentation_object.get_sampling_frequency())
 
-    # defining the abstract class enformed methods:
-    def get_roi_ids(self):
-        return list(range(self.get_num_rois()))
-
     def get_image_size(self):
         return self._image_masks.shape[0:2]

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -79,10 +79,6 @@ class ExtractSegmentationExtractor(SegmentationExtractor):
         ac_set = set(self.get_accepted_list())
         return [a for a in range(self.get_num_rois()) if a not in ac_set]
 
-    # defining the abstract class informed methods:
-    def get_roi_ids(self):
-        return list(range(self.get_num_rois()))
-
     def get_image_size(self):
         return self._image_masks.shape[0:2]
 

--- a/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -155,9 +155,5 @@ class SimaSegmentationExtractor(SegmentationExtractor):
     def write_segmentation(segmentation_object, savepath):
         raise NotImplementedError
 
-    # defining the abstract class enformed methods:
-    def get_roi_ids(self):
-        return list(range(self.get_num_rois()))
-
     def get_image_size(self):
         return self._image_masks.shape[0:2]

--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -96,10 +96,6 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
     def roi_locations(self):
         return np.array([j["med"] for j in self.stat]).T.astype(int)
 
-    # defining the abstract class enforced methods:
-    def get_roi_ids(self):
-        return list(range(self.get_num_rois()))
-
     def get_roi_image_masks(self, roi_ids=None):
         if roi_ids is None:
             roi_idx_ = range(self.get_num_rois())

--- a/src/roiextractors/multisegmentationextractor.py
+++ b/src/roiextractors/multisegmentationextractor.py
@@ -117,9 +117,6 @@ class MultiSegmentationExtractor(SegmentationExtractor):
     def get_roi_image_masks(self, roi_ids=None):
         return lambda x: np.concatenate(x, axis=2)
 
-    def get_roi_ids(self):
-        return self._all_roi_ids
-
     @concatenate_output
     def get_roi_locations(self, roi_ids=None):
         return lambda x: np.concatenate(x, axis=1)

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -233,6 +233,9 @@ class SegmentationExtractor(ABC, BaseExtractor):
         sampling_frequency: float
             Sampling frequency of the recording in Hz.
         """
+        if self._sampling_frequency is not None:
+            return float(self._sampling_frequency)
+
         return self._sampling_frequency
 
     def get_num_rois(self):

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import Union
 
 import numpy as np
 from spikeextractors.baseextractor import BaseExtractor
 
-from .extraction_tools import ArrayType
+from .extraction_tools import ArrayType, IntType, FloatType
 from .extraction_tools import _pixel_mask_extractor
 
 
@@ -103,7 +104,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         Returns
         -------
         roi_ids: list
-            ROI ids list.
+            List of roi ids.
         """
         return list(range(self.get_num_rois()))
 
@@ -268,12 +269,30 @@ class SegmentationExtractor(ABC, BaseExtractor):
     def get_num_planes(self):
         """
         Returns the default number of planes of imaging for the segmentation extractor.
-        Detaults to 1 for all but the MultiSegmentationExtractor
+        Defaults to 1 for all but the MultiSegmentationExtractor
         Returns
         -------
         self._num_planes: int
         """
         return self._num_planes
+
+    def frame_to_time(self, frame_indices: Union[IntType, ArrayType]) -> Union[FloatType, ArrayType]:
+        """Returns the timing of frames in unit of seconds.
+
+        Parameters
+        ----------
+        frame_indices: int or array-like
+            The frame or frames to be converted to times
+
+        Returns
+        -------
+        times: float or array-like
+            The corresponding times in seconds
+        """
+        if self._times is None:
+            return np.round(frame_indices / self.get_sampling_frequency(), 6)
+        else:
+            return self._times[frame_indices]
 
     @staticmethod
     def write_segmentation(segmentation_extractor, save_path, overwrite=False):

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -240,8 +240,8 @@ class SegmentationExtractor(ABC, BaseExtractor):
 
         Returns
         -------
-        no_rois: int
-            integer number of ROIs extracted.
+        num_rois: int
+            The number of ROIs extracted.
         """
         for trace in self.get_traces_dict().values():
             if trace is not None and len(trace.shape) > 0:

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -230,10 +230,10 @@ class SegmentationExtractor(ABC, BaseExtractor):
 
         Returns
         -------
-        samp_freq: float
-            Sampling frequency of the recordings in Hz.
+        sampling_frequency: float
+            Sampling frequency of the recording in Hz.
         """
-        return float(self._sampling_frequency)
+        return self._sampling_frequency
 
     def get_num_rois(self):
         """Returns total number of Regions of Interest in the acquired images.

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -12,7 +12,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
     An abstract class that contains all the meta-data and output data from
     the ROI segmentation operation when applied to the pre-processed data.
     It also contains methods to read from and write to various data formats
-    ouput from the processing pipelines like SIMA, CaImAn, Suite2p, CNNM-E.
+    output from the processing pipelines like SIMA, CaImAn, Suite2p, CNNM-E.
     All the methods with @abstract decorator have to be defined by the
     format specific classes that inherit from this.
     """
@@ -98,16 +98,14 @@ class SegmentationExtractor(ABC, BaseExtractor):
             roi_location[:, c] = np.array([np.median(temp[0]), np.median(temp[1])]).T
         return roi_location
 
-    @abstractmethod
     def get_roi_ids(self) -> list:
-        """Returns the list of channel ids. If not specified, the range from 0 to num_channels - 1 is returned.
-
+        """Returns the list of ROI ids.
         Returns
         -------
         roi_ids: list
-            List of roi ids.
+            ROI ids list.
         """
-        pass
+        return list(range(self.get_num_rois()))
 
     def get_roi_image_masks(self, roi_ids=None) -> np.array:
         """Returns the image masks extracted from segmentation algorithm.

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -210,6 +210,11 @@ def check_segmentations_equal(
     assert_array_equal(segmentation_extractor1.get_roi_ids(), segmentation_extractor2.get_roi_ids())
     assert_array_equal(segmentation_extractor1.get_traces(), segmentation_extractor2.get_traces())
 
+    assert_array_equal(
+        segmentation_extractor1.frame_to_time(np.arange(segmentation_extractor1.get_num_frames())),
+        segmentation_extractor2.frame_to_time(np.arange(segmentation_extractor2.get_num_frames())),
+    )
+
 
 def check_segmentation_return_types(seg: SegmentationExtractor):
     """

--- a/tests/test_internals/test_testing_tools.py
+++ b/tests/test_internals/test_testing_tools.py
@@ -1,5 +1,8 @@
 import unittest
 
+import numpy as np
+from numpy.testing import assert_array_equal
+
 from roiextractors.testing import generate_dummy_segmentation_extractor
 
 
@@ -28,6 +31,11 @@ class TestDummySegmentationExtractor(unittest.TestCase):
         assert segmentation_extractor.get_accepted_list() == segmentation_extractor.get_roi_ids()
         assert segmentation_extractor.get_rejected_list() == []
         assert segmentation_extractor.get_roi_locations().shape == (2, self.num_rois)
+
+        # Test frame_to_time
+        times = np.round(np.arange(self.num_frames) / self.sampling_frequency, 6)
+        assert_array_equal(segmentation_extractor.frame_to_time(frame_indices=np.arange(self.num_frames)), times)
+        self.assertEqual(segmentation_extractor.frame_to_time(frame_indices=8), times[8])
 
         # Test image masks
         assert segmentation_extractor.get_roi_image_masks().shape == (self.num_rows, self.num_columns, self.num_rois)
@@ -70,3 +78,19 @@ class TestDummySegmentationExtractor(unittest.TestCase):
         assert segmentation_extractor.get_traces(name="dff").shape == (self.num_rois, self.num_frames)
         assert segmentation_extractor.get_traces(name="deconvolved").shape == (self.num_rois, self.num_frames)
         assert segmentation_extractor.get_traces(name="neuropil").shape == (self.num_rois, self.num_frames)
+
+    def test_frame_to_time_no_sampling_frequency(self):
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            sampling_frequency=None,
+        )
+
+        times = np.arange(self.num_frames) / self.sampling_frequency
+        segmentation_extractor._times = times
+
+        self.assertEqual(segmentation_extractor.frame_to_time(frame_indices=2), times[2])
+        assert_array_equal(
+            segmentation_extractor.frame_to_time(
+                frame_indices=np.arange(self.num_frames),
+            ),
+            times,
+        )


### PR DESCRIPTION
- Adds frame_to_time method in SegmentationExtractor: can be used to define timestamps when writing segmentation data to NWB
- get_roi_ids can be used from SegmentationExtractor, no need to define in child classes if they are using the same logic. 
- Other smaller changes: refactor docstrings, get_sampling_frequency will not break if private attribute _sampling_frequency is None
