### PR TITLE
`SegmentationExtractor`: add `set_times`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The `ExtractSegmentatioExtractor` class `write_segmentation` method has now been
 
 ### Improvements
 * Add `frame_to_time` to `SegmentationExtractor`, `get_roi_ids` is now a class method. [PR #187](https://github.com/catalystneuro/roiextractors/pull/187)
+* Add `set_times` to `SegmentationExtractor`. [PR #188](https://github.com/catalystneuro/roiextractors/pull/188)
 
 ### Fixes
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -279,7 +279,6 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         return self._num_planes
 
-
     def set_times(self, times: ArrayType):
         """Sets the recording times in seconds for each frame.
 
@@ -290,7 +289,6 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
         self._times = np.array(times, dtype=np.float64)
-
 
     def frame_to_time(self, frame_indices: Union[IntType, ArrayType]) -> Union[FloatType, ArrayType]:
         """Returns the timing of frames in unit of seconds.
@@ -309,7 +307,6 @@ class SegmentationExtractor(ABC, BaseExtractor):
             return np.round(frame_indices / self.get_sampling_frequency(), 6)
         else:
             return self._times[frame_indices]
-
 
     @staticmethod
     def write_segmentation(segmentation_extractor, save_path, overwrite=False):

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -285,8 +285,8 @@ class SegmentationExtractor(ABC, BaseExtractor):
         times: array-like
             The times in seconds for each frame
         """
-        assert len(times) == self.get_num_frames(), ("'times' should have the same length of the number of frames!",)
-        self._times = np.array(times).astype("float64")
+        assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
+        self._times = np.array(times, dtype=np.float64)
 
     @staticmethod
     def write_segmentation(segmentation_extractor, save_path, overwrite=False):

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -277,6 +277,19 @@ class SegmentationExtractor(ABC, BaseExtractor):
         """
         return self._num_planes
 
+    def set_times(self, times: ArrayType):
+        """Sets the recording times in seconds for each frame.
+
+        Parameters
+        ----------
+        times: array-like
+            The times in seconds for each frame
+        """
+        assert len(times) == self.get_num_frames(), (
+            "'times' should have the same length of the number of frames!",
+        )
+        self._times = np.array(times).astype("float64")
+
     @staticmethod
     def write_segmentation(segmentation_extractor, save_path, overwrite=False):
         """

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -285,9 +285,7 @@ class SegmentationExtractor(ABC, BaseExtractor):
         times: array-like
             The times in seconds for each frame
         """
-        assert len(times) == self.get_num_frames(), (
-            "'times' should have the same length of the number of frames!",
-        )
+        assert len(times) == self.get_num_frames(), ("'times' should have the same length of the number of frames!",)
         self._times = np.array(times).astype("float64")
 
     @staticmethod

--- a/tests/test_internals/test_testing_tools.py
+++ b/tests/test_internals/test_testing_tools.py
@@ -103,7 +103,7 @@ class TestDummySegmentationExtractor(TestCase):
         # Set times with an array that is too short
         times_to_set = np.round(np.arange(num_frames - 1) / sampling_frequency, 6)
         with self.assertRaisesWith(
-                exc_type=AssertionError,
-                exc_msg="'times' should have the same length of the number of frames!",
+            exc_type=AssertionError,
+            exc_msg="'times' should have the same length of the number of frames!",
         ):
             segmentation_extractor.set_times(times_to_set)


### PR DESCRIPTION
Follow up on #187

Adds `set_times` method to SegmentationExtractor.
The use case is to be able to write segmentation data with timestamps.