### PR TITLE
[refactor] `NwbSegmentationExtractor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ extractor depending on the version of the file. [PR #170](https://github.com/cat
 * Add `frame_to_time` to `SegmentationExtractor`, `get_roi_ids` is now a class method. [PR #187](https://github.com/catalystneuro/roiextractors/pull/187)
 * Add `set_times` to `SegmentationExtractor`. [PR #188](https://github.com/catalystneuro/roiextractors/pull/188)
 * Updated the test for segmentation images to check all images for the given segmentation extractors. [PR #190](https://github.com/catalystneuro/roiextractors/pull/190)
+* Refactored the `NwbSegmentationExtractor` to be more flexible with segmentation images and keep up
+  with the change in [catalystneuro/neuoroconv#41](https://github.com/catalystneuro/neuroconv/pull/41) 
+  of trace names. [PR #191](https://github.com/catalystneuro/roiextractors/pull/191)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ extractor depending on the version of the file. [PR #170](https://github.com/cat
 * Add `set_times` to `SegmentationExtractor`. [PR #188](https://github.com/catalystneuro/roiextractors/pull/188)
 * Updated the test for segmentation images to check all images for the given segmentation extractors. [PR #190](https://github.com/catalystneuro/roiextractors/pull/190)
 * Refactored the `NwbSegmentationExtractor` to be more flexible with segmentation images and keep up
-  with the change in [catalystneuro/neuoroconv#41](https://github.com/catalystneuro/neuroconv/pull/41) 
+  with the change in [catalystneuro/neuoroconv#41](https://github.com/catalystneuro/neuroconv/pull/41)
   of trace names. [PR #191](https://github.com/catalystneuro/roiextractors/pull/191)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Features
 * Add support for newer versions of EXTRACT output files.
 The `ExtractSegmentationExtractor` class is now abstract and redirects to the newer or older
-extractor depending on the version of the file.
-The `ExtractSegmentatioExtractor` class `write_segmentation` method has now been deprecated. [PR #170](https://github.com/catalystneuro/roiextractors/pull/170)
+extractor depending on the version of the file. [PR #170](https://github.com/catalystneuro/roiextractors/pull/170)
+* The `ExtractSegmentationExtractor.write_segmentation` method has now been deprecated. [PR #170](https://github.com/catalystneuro/roiextractors/pull/170)
 
 ### Improvements
 * Add `frame_to_time` to `SegmentationExtractor`, `get_roi_ids` is now a class method. [PR #187](https://github.com/catalystneuro/roiextractors/pull/187)

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -328,9 +328,11 @@ class NwbSegmentationExtractor(SegmentationExtractor):
                 return rej_list
 
     def get_images_dict(self):
-        if self._segmentation_images is None:
-            return super().get_images_dict()
-        images_dict = {image_name: image_data[:].T for image_name, image_data in self._segmentation_images.items()}
+        images_dict = super().get_images_dict()
+        if self._segmentation_images is not None:
+            images_dict.update(
+                (image_name, image_data[:].T) for image_name, image_data in self._segmentation_images.items()
+            )
 
         return images_dict
 

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -240,7 +240,8 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
         images_dict: dict
             dictionary with key, values representing different types of Images
         """
-        images_dict = dict(
+        images_dict = super().get_images_dict()
+        images_dict.update(
             summary_image=self._info_struct["summary_image"][:],
             f_per_pixel=self._info_struct["F_per_pixel"][:],
             max_image=self._info_struct["max_image"][:],

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -240,8 +240,7 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
         images_dict: dict
             dictionary with key, values representing different types of Images
         """
-        images_dict = super().get_images_dict()
-        images_dict.update(
+        images_dict = dict(
             summary_image=self._info_struct["summary_image"][:],
             f_per_pixel=self._info_struct["F_per_pixel"][:],
             max_image=self._info_struct["max_image"][:],


### PR DESCRIPTION
Updating `NwbSegmentationExtractor`  is necessary after merging [catalystneuro/neuoroconv#41](https://github.com/catalystneuro/neuroconv/pull/41) to keep up with the change of trace names.
The `get_images_dict()` is also changed to be more flexible if there are other segmentation images than correlation or mean images. 

This PR prepares the update of `ExtractSegmentationInterface` in catalystneuro/neuroconv#87.