### PR TITLE
Follow-up on `ExtractSegmentationExtractor`

### DIFF
--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -1,7 +1,6 @@
 """Extractor for reading the segmentation data that results from calls to EXTRACT."""
 from abc import ABC
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 from lazy_ops import DatasetView
@@ -16,7 +15,6 @@ except ImportError:
 
 
 from ...extraction_tools import PathType, ArrayType
-from ...multisegmentationextractor import MultiSegmentationExtractor
 from ...segmentationextractor import SegmentationExtractor
 
 

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -243,9 +243,9 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
             dictionary with key, values representing different types of Images
         """
         images_dict = dict(
-            summary_image=DatasetView(self._info_struct["summary_image"]),
-            f_per_pixel=DatasetView(self._info_struct["F_per_pixel"]),
-            max_image=DatasetView(self._info_struct["max_image"]),
+            summary_image=self._info_struct["summary_image"][:],
+            f_per_pixel=self._info_struct["F_per_pixel"][:],
+            max_image=self._info_struct["max_image"][:],
         )
 
         return images_dict

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -172,9 +172,7 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
                     data = _decode_h5py_array(data)
                 config_dict[property_name] = data
             elif isinstance(config_struct[property_name], h5py.Group):
-                config_dict.update(
-                    self._config_struct_to_dict(config_struct=config_struct[property_name])
-                )
+                config_dict.update(self._config_struct_to_dict(config_struct=config_struct[property_name]))
         return config_dict
 
     def _image_mask_extractor_read(self) -> DatasetView:

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -153,6 +153,8 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
 
         assert "info" in self._output_struct, "Info struct not found in file."
         self._info_struct = self._output_struct["info"]
+        extract_version = np.ravel(self._info_struct["version"][:])
+        self.config.update(version=_decode_h5py_array(extract_version))
 
     def close(self):
         self._dataset_file.close()

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -172,7 +172,9 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
                     data = _decode_h5py_array(data)
                 config_dict[property_name] = data
             elif isinstance(config_struct[property_name], h5py.Group):
-                config_dict[property_name] = self._config_struct_to_dict(config_struct=config_struct[property_name])
+                config_dict.update(
+                    self._config_struct_to_dict(config_struct=config_struct[property_name])
+                )
         return config_dict
 
     def _image_mask_extractor_read(self) -> DatasetView:

--- a/tests/test_extractsegmentationextractor.py
+++ b/tests/test_extractsegmentationextractor.py
@@ -143,15 +143,19 @@ class TestNewExtractSegmentationExtractor(TestCase):
     def test_extractor_config(self):
         """Test that the extractor class returns the expected config."""
 
+        # Assert that all keys are extracted without nesting
+        self.assertEqual(len(self.extractor.config), 93)
+        assert "version" in self.extractor.config
+        self.assertEqual(self.extractor.config["version"], "1.1.0")
+
         assert "preprocess" in self.extractor.config
         self.assertEqual(self.extractor.config["preprocess"], [1])
 
         assert "S_corr_thresh" in self.extractor.config
         self.assertEqual(self.extractor.config["S_corr_thresh"], [0.1])
 
-        assert "thresholds" in self.extractor.config
-        self.assertEqual(self.extractor.config["thresholds"]["S_dup_corr_thresh"], [0.95])
-        self.assertEqual(self.extractor.config["thresholds"]["T_dup_corr_thresh"], [0.95])
+        self.assertEqual(self.extractor.config["S_dup_corr_thresh"], [0.95])
+        self.assertEqual(self.extractor.config["T_dup_corr_thresh"], [0.95])
 
         assert "trace_output_option" in self.extractor.config
         self.assertEqual(self.extractor.config["trace_output_option"], "raw")


### PR DESCRIPTION
- the version number of the file should be added to config 
- segmentation images dtype changes to ndarray, using DatasetView here errors out when writing GrayscaleImage if image data is not ndarray
- flattens out config to match the expected keys in `ndx-extract` extension