### PR TITLE
[Fix] get segmentation images in `NewExtractSegmentationExtractor`

### DIFF
--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -240,7 +240,8 @@ class NewExtractSegmentationExtractor(SegmentationExtractor):
         images_dict: dict
             dictionary with key, values representing different types of Images
         """
-        images_dict = dict(
+        images_dict = super().get_images_dict()
+        images_dict.update(
             summary_image=self._info_struct["summary_image"][:],
             f_per_pixel=self._info_struct["F_per_pixel"][:],
             max_image=self._info_struct["max_image"][:],

--- a/tests/test_extractsegmentationextractor.py
+++ b/tests/test_extractsegmentationextractor.py
@@ -199,7 +199,10 @@ class TestNewExtractSegmentationExtractor(TestCase):
             )[:]
 
         images_dict = self.extractor.get_images_dict()
-        self.assertEqual(len(images_dict), 3)
+        self.assertEqual(len(images_dict), 5)
+
+        self.assertEqual(images_dict["correlation"], None)
+        self.assertEqual(images_dict["mean"], None)
 
         self.assertEqual(images_dict["summary_image"].shape, summary_image.shape)
         self.assertEqual(images_dict["max_image"].shape, max_image.shape)


### PR DESCRIPTION
Connected to #191 and catalystneuro/neuroconv#87 to make the gin tests pass for all segmentation datasets.

See conversation in #191