### PR TITLE
[Merge after #200]: Subframe segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ extractor depending on the version of the file. [PR #170](https://github.com/cat
 * Implemented a more efficient case of the base `ImagingExtractor.get_frames` through `get_video` when the indices are contiguous. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
 * Removed `max_frame` check on `MultiImagingExtractor.get_video()` to adhere to upper-bound slicing semantics. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
 * Improved the `MultiImagingExtractor.get_video()` to no longer rely on `get_frames`. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
-* Adding `dtype` consistency check across `MultiImaging` components as well as a direct override method. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
+* Added `dtype` consistency check across `MultiImaging` components as well as a direct override method. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
+* Added the `FrameSliceSegmentationExtractor` class and corresponding `Segmentation.frame_slice(...)` method. [PR #201](https://github.com/catalystneuro/neuroconv/pull/201)
 
 ### Fixes
 * Fixed the reference to the proper `mov_field` in `Hdf5ImagingExtractor`. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ...extraction_tools import PathType, FloatType, ArrayType
-from ...extraction_tools import check_get_frames_args, get_video_shape
+from ...extraction_tools import get_video_shape
 from ...imagingextractor import ImagingExtractor
 from ...segmentationextractor import SegmentationExtractor
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -386,33 +386,12 @@ class FrameSliceSegmentationExtractor(SegmentationExtractor):
         )
 
     def get_traces_dict(self):
-        for trace in self._parent_segmentation.get_traces_dict().values():
-            if trace is not None and len(trace.shape) > 0:
-                if not isinstance(trace, np.ndarray):
-                    raise NotImplementedError(
-                        "The `get_traces_dict` method for SubFrameSegementations does not yet support underlying trace "
-                        "types other than numpy arrays (which includes memory maps)."
-                    )
-
-        def _safe_subtrace(trace: Optional[np.ndarray], start: int, end: int):
-            if trace is None and len(trace.shape) > 0:
-                return None
-            return trace[start:end, :]
-
-        return dict(
-            raw=_safe_subtrace(
-                trace=self._parent_segmentation._roi_response_raw, start=self._start_frame, end=self._end_frame
-            ),
-            dff=_safe_subtrace(
-                trace=self._parent_segmentation._roi_response_dff, start=self._start_frame, end=self._end_frame
-            ),
-            neuropil=_safe_subtrace(
-                trace=self._parent_segmentation._roi_response_neuropil, start=self._start_frame, end=self._end_frame
-            ),
-            deconvolved=_safe_subtrace(
-                trace=self._parent_segmentation._roi_response_deconvolved, start=self._start_frame, end=self._end_frame
-            ),
-        )
+        return {
+            trace_name: self._parent_segmentation.get_traces(
+                start_frame=self._start_frame, end_frame=self._end_frame, name=trace_name
+            )
+            for trace_name, trace in self._parent_segmentation.get_traces_dict().items()
+        }
 
     def get_image_size(self) -> Tuple[int, int]:
         return tuple(self._parent_segmentation.get_image_size())

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -385,16 +385,18 @@ class FrameSliceSegmentationExtractor(SegmentationExtractor):
         )
 
     def get_traces_dict(self):
-        if not isinstance(self._parent_segmentation._roi_response_raw, np.ndarray):
-            raise NotImplementedError(
-                "The `get_traces_dict` method for SubFrameSegementations does not yet support underlying trace types "
-                "other than numpy arrays (which includes memory maps)."
-            )
+        for trace in self._parent_segmentation.get_traces_dict().values():
+            if trace is not None and len(trace.shape) > 0:
+                if not isinstance(trace, np.ndarray):
+                    raise NotImplementedError(
+                        "The `get_traces_dict` method for SubFrameSegementations does not yet support underlying trace "
+                        "types other than numpy arrays (which includes memory maps)."
+                    )
 
         def _safe_subtrace(trace: Optional[np.ndarray], start_frame: int, end_frame: int):
-            if trace is None:
+            if trace is None and len(trace.shape) > 0:
                 return None
-            return trace[:, start_frame:end_frame]
+            return trace[start_frame:end_frame, :]
 
         return dict(
             raw=_safe_subtrace(

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -144,6 +144,7 @@ def generate_dummy_segmentation_extractor(
         accepted_lst=accepeted_list,
         rejected_list=rejected_list,
         movie_dims=movie_dims,
+        channel_names=["channel_num_0"],
     )
 
     return dummy_segmentation_extractor

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -30,7 +30,7 @@ def segmentation_name_function(testcase_function, param_number, param):
     return f"{testcase_function.__name__}_{param_number}_{parameterized.to_safe_name(param.kwargs['name'])}"
 
 
-class TestFrameSlicesegmentation(TestCase):
+class BaseTestFrameSlicesegmentation(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.toy_segmentation_example = generate_dummy_segmentation_extractor(num_frames=15, num_rows=5, num_columns=4)
@@ -78,7 +78,7 @@ class TestFrameSlicesegmentation(TestCase):
     def test_get_traces_dict(self):
         true_dict = self.toy_segmentation_example.get_traces_dict()
         for key in true_dict:
-            true_dict[key] = true_dict[key][2:7, :]
+            true_dict[key] = true_dict[key][2:7, :] if true_dict[key] is not None else true_dict[key]
         self.assertCountEqual(first=self.frame_sliced_segmentation.get_traces_dict(), second=true_dict)
 
     def test_get_images_dict(self):
@@ -92,6 +92,15 @@ class TestFrameSlicesegmentation(TestCase):
         assert_array_equal(
             x=self.frame_sliced_segmentation.get_image(name=name), y=self.toy_segmentation_example.get_image(name=name)
         )
+
+
+class TestMissingTraceFrameSlicesegmentation(BaseTestFrameSlicesegmentation):
+    @classmethod
+    def setUpClass(cls):
+        cls.toy_segmentation_example = generate_dummy_segmentation_extractor(
+            num_frames=15, num_rows=5, num_columns=4, has_dff_signal=False
+        )
+        cls.frame_sliced_segmentation = cls.toy_segmentation_example.frame_slice(start_frame=2, end_frame=7)
 
 
 if __name__ == "__main__":

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -14,9 +14,7 @@ def test_frame_slicing_segmentation_times():
     times = np.array(range(num_frames)) + timestamp_shift
     start_frame, end_frame = 2, 7
 
-    toy_segmentation_example = generate_dummy_segmentation_extractor(
-        num_frames=num_frames, num_rows=5, num_columns=4, num_channels=1
-    )
+    toy_segmentation_example = generate_dummy_segmentation_extractor(num_frames=num_frames, num_rows=5, num_columns=4)
     toy_segmentation_example.set_times(times=times)
 
     frame_sliced_segmentation = toy_segmentation_example.frame_slice(start_frame=start_frame, end_frame=end_frame)
@@ -29,13 +27,13 @@ def test_frame_slicing_segmentation_times():
 
 
 def segmentation_name_function(testcase_function, param_number, param):
-    return f"{testcase_function.__name__}_{param_number}_{parameterized.to_safe_name(param.kwargs['name'].__name__)}"
+    return f"{testcase_function.__name__}_{param_number}_{parameterized.to_safe_name(param.kwargs['name'])}"
 
 
 class TestFrameSlicesegmentation(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.toy_segmentation_example = generate_dummy_segmentation_extractor(num_frames=10, num_rows=5, num_columns=4)
+        cls.toy_segmentation_example = generate_dummy_segmentation_extractor(num_frames=15, num_rows=5, num_columns=4)
         cls.frame_sliced_segmentation = cls.toy_segmentation_example.frame_slice(start_frame=2, end_frame=7)
 
     def test_get_image_size(self):
@@ -57,7 +55,7 @@ class TestFrameSlicesegmentation(TestCase):
         assert self.frame_sliced_segmentation.get_num_channels() == 1
 
     def test_get_num_rois(self):
-        assert self.frame_sliced_segmentation.get_num_rois() == 30
+        assert self.frame_sliced_segmentation.get_num_rois() == 10
 
     def test_get_accepted_list(self):
         return assert_array_equal(
@@ -65,10 +63,7 @@ class TestFrameSlicesegmentation(TestCase):
         )
 
     def test_get_rejected_list(self):
-        return assert_array_equal(
-            x=self.frame_sliced_segmentation.get_rejected_list(),
-            y=[10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-        )
+        return assert_array_equal(x=self.frame_sliced_segmentation.get_rejected_list(), y=[])
 
     @parameterized.expand(
         [param(name="raw"), param(name="dff"), param(name="neuropil"), param(name="deconvolved")],
@@ -84,17 +79,19 @@ class TestFrameSlicesegmentation(TestCase):
         true_dict = self.toy_segmentation_example.get_traces_dict()
         for key in true_dict:
             true_dict[key] = true_dict[key][2:7, :]
-        self.assertContainerEqual(container1=self.frame_sliced_segmentation.get_traces_dict(), container2=true_dict)
+        self.assertCountEqual(first=self.frame_sliced_segmentation.get_traces_dict(), second=true_dict)
 
     def test_get_images_dict(self):
-        self.assertContainerEqual(
-            container1=self.frame_sliced_segmentation.get_images_dict(),
-            container2=self.toy_segmentation_example.get_images_dict(),
+        self.assertCountEqual(
+            first=self.frame_sliced_segmentation.get_images_dict(),
+            second=self.toy_segmentation_example.get_images_dict(),
         )
 
     @parameterized.expand([param(name="mean"), param(name="correlation")], name_func=segmentation_name_function)
     def test_get_image(self, name: str):
-        assert self.frame_sliced_segmentation.get_image(name=name) == self.toy_segmentation_example.get_image(name=name)
+        assert_array_equal(
+            x=self.frame_sliced_segmentation.get_image(name=name), y=self.toy_segmentation_example.get_image(name=name)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -1,0 +1,101 @@
+import unittest
+
+import numpy as np
+from hdmf.testing import TestCase
+from numpy.testing import assert_array_equal
+from parameterized import parameterized, param
+
+from roiextractors.testing import generate_dummy_segmentation_extractor
+
+
+def test_frame_slicing_segmentation_times():
+    num_frames = 10
+    timestamp_shift = 7.1
+    times = np.array(range(num_frames)) + timestamp_shift
+    start_frame, end_frame = 2, 7
+
+    toy_segmentation_example = generate_dummy_segmentation_extractor(
+        num_frames=num_frames, num_rows=5, num_columns=4, num_channels=1
+    )
+    toy_segmentation_example.set_times(times=times)
+
+    frame_sliced_segmentation = toy_segmentation_example.frame_slice(start_frame=start_frame, end_frame=end_frame)
+    assert_array_equal(
+        frame_sliced_segmentation.frame_to_time(
+            frames=np.array([idx for idx in range(frame_sliced_segmentation.get_num_frames())])
+        ),
+        times[start_frame:end_frame],
+    )
+
+
+def segmentation_name_function(testcase_function, param_number, param):
+    return f"{testcase_function.__name__}_{param_number}_{parameterized.to_safe_name(param.kwargs['name'].__name__)}"
+
+
+class TestFrameSlicesegmentation(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.toy_segmentation_example = generate_dummy_segmentation_extractor(num_frames=10, num_rows=5, num_columns=4)
+        cls.frame_sliced_segmentation = cls.toy_segmentation_example.frame_slice(start_frame=2, end_frame=7)
+
+    def test_get_image_size(self):
+        assert self.frame_sliced_segmentation.get_image_size() == (5, 4)
+
+    def test_get_num_planes(self):
+        return self.frame_sliced_segmentation.get_num_planes() == 1
+
+    def test_get_num_frames(self):
+        assert self.frame_sliced_segmentation.get_num_frames() == 5
+
+    def test_get_sampling_frequency(self):
+        assert self.frame_sliced_segmentation.get_sampling_frequency() == 30.0
+
+    def test_get_channel_names(self):
+        assert self.frame_sliced_segmentation.get_channel_names() == ["channel_num_0"]
+
+    def test_get_num_channels(self):
+        assert self.frame_sliced_segmentation.get_num_channels() == 1
+
+    def test_get_num_rois(self):
+        assert self.frame_sliced_segmentation.get_num_rois() == 30
+
+    def test_get_accepted_list(self):
+        return assert_array_equal(
+            x=self.frame_sliced_segmentation.get_accepted_list(), y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
+
+    def test_get_rejected_list(self):
+        return assert_array_equal(
+            x=self.frame_sliced_segmentation.get_rejected_list(),
+            y=[10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+        )
+
+    @parameterized.expand(
+        [param(name="raw"), param(name="dff"), param(name="neuropil"), param(name="deconvolved")],
+        name_func=segmentation_name_function,
+    )
+    def test_get_traces(self, name: str):
+        assert_array_equal(
+            x=self.frame_sliced_segmentation.get_traces(name=name),
+            y=self.toy_segmentation_example.get_traces(start_frame=2, end_frame=7, name=name),
+        )
+
+    def test_get_traces_dict(self):
+        true_dict = self.toy_segmentation_example.get_traces_dict()
+        for key in true_dict:
+            true_dict[key] = true_dict[key][:, 2:7]
+        self.assertContainerEqual(container1=self.frame_sliced_segmentation.get_traces_dict(), container2=true_dict)
+
+    def test_get_images_dict(self):
+        self.assertContainerEqual(
+            container1=self.frame_sliced_segmentation.get_images_dict(),
+            container2=self.toy_segmentation_example.get_images_dict(),
+        )
+
+    @parameterized.expand([param(name="mean"), param(name="correlation")], name_func=segmentation_name_function)
+    def test_get_image(self, name: str):
+        assert self.frame_sliced_segmentation.get_image(name=name) == self.toy_segmentation_example.get_image(name=name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -83,7 +83,7 @@ class TestFrameSlicesegmentation(TestCase):
     def test_get_traces_dict(self):
         true_dict = self.toy_segmentation_example.get_traces_dict()
         for key in true_dict:
-            true_dict[key] = true_dict[key][:, 2:7]
+            true_dict[key] = true_dict[key][2:7, :]
         self.assertContainerEqual(container1=self.frame_sliced_segmentation.get_traces_dict(), container2=true_dict)
 
     def test_get_images_dict(self):

--- a/tests/test_internals/test_testing_tools.py
+++ b/tests/test_internals/test_testing_tools.py
@@ -33,8 +33,8 @@ class TestDummySegmentationExtractor(TestCase):
 
         # Test frame_to_time
         times = np.round(np.arange(self.num_frames) / self.sampling_frequency, 6)
-        assert_array_equal(segmentation_extractor.frame_to_time(frame_indices=np.arange(self.num_frames)), times)
-        self.assertEqual(segmentation_extractor.frame_to_time(frame_indices=8), times[8])
+        assert_array_equal(segmentation_extractor.frame_to_time(frames=np.arange(self.num_frames)), times)
+        self.assertEqual(segmentation_extractor.frame_to_time(frames=8), times[8])
 
         # Test image masks
         assert segmentation_extractor.get_roi_image_masks().shape == (self.num_rows, self.num_columns, self.num_rois)
@@ -118,10 +118,8 @@ class TestDummySegmentationExtractor(TestCase):
         times = np.arange(self.num_frames) / self.sampling_frequency
         segmentation_extractor._times = times
 
-        self.assertEqual(segmentation_extractor.frame_to_time(frame_indices=2), times[2])
+        self.assertEqual(segmentation_extractor.frame_to_time(frames=2), times[2])
         assert_array_equal(
-            segmentation_extractor.frame_to_time(
-                frame_indices=np.arange(self.num_frames),
-            ),
+            segmentation_extractor.frame_to_time(frames=np.arange(self.num_frames)),
             times,
         )


### PR DESCRIPTION
Relies on trace orientation fix/standardization in #200.

Introduces subframe selection capabilities to SegmentationExtractors as well as tests for this.

Necessary to introduce frame stubbing into the SegmentationDataInterface on NeuroConv.