### PR TITLE
Relax rounding of frame_to_time()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ extractor depending on the version of the file. [PR #170](https://github.com/cat
 * Improved the `MultiImagingExtractor.get_video()` to no longer rely on `get_frames`. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
 * Added `dtype` consistency check across `MultiImaging` components as well as a direct override method. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)
 * Added the `FrameSliceSegmentationExtractor` class and corresponding `Segmentation.frame_slice(...)` method. [PR #201](https://github.com/catalystneuro/neuroconv/pull/201)
+* Relaxed rounding of `ImagingExtractor.frame_to_time(...)` and `SegmentationExtractor.frame_to_time(...)` to be more consistent with SpikeInterface. [PR #212](https://github.com/catalystneuro/roiextractors/pull/212)
 
 ### Fixes
 * Fixed the reference to the proper `mov_field` in `Hdf5ImagingExtractor`. [PR #195](https://github.com/catalystneuro/neuroconv/pull/195)

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -81,7 +81,7 @@ class ImagingExtractor(ABC):
         """
         # Default implementation
         if self._times is None:
-            return np.round(frames / self.get_sampling_frequency(), 6)
+            return frames / self.get_sampling_frequency()
         else:
             return self._times[frames]
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -302,7 +302,7 @@ class SegmentationExtractor(ABC):
             The corresponding times in seconds
         """
         if self._times is None:
-            return np.round(frames / self.get_sampling_frequency(), 6)
+            return frames / self.get_sampling_frequency()
         else:
             return self._times[frames]
 

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -192,7 +192,7 @@ def check_segmentations_equal(
     assert segmentation_extractor1.get_num_rois() == segmentation_extractor2.get_num_rois()
     assert segmentation_extractor1.get_num_frames() == segmentation_extractor2.get_num_frames()
     assert segmentation_extractor1.get_num_channels() == segmentation_extractor2.get_num_channels()
-    assert segmentation_extractor1.get_sampling_frequency() == segmentation_extractor2.get_sampling_frequency()
+    assert np.isclose(segmentation_extractor1.get_sampling_frequency(), segmentation_extractor2.get_sampling_frequency())
     assert_array_equal(segmentation_extractor1.get_channel_names(), segmentation_extractor2.get_channel_names())
     assert_array_equal(segmentation_extractor1.get_image_size(), segmentation_extractor2.get_image_size())
     assert_array_equal(

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -215,7 +215,7 @@ def check_segmentations_equal(
     assert_array_equal(segmentation_extractor1.get_roi_ids(), segmentation_extractor2.get_roi_ids())
     assert_array_equal(segmentation_extractor1.get_traces(), segmentation_extractor2.get_traces())
 
-    assert_array_almost_equal(
+    assert_array_equal(
         segmentation_extractor1.frame_to_time(np.arange(segmentation_extractor1.get_num_frames())),
         segmentation_extractor2.frame_to_time(np.arange(segmentation_extractor2.get_num_frames())),
     )

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -192,7 +192,9 @@ def check_segmentations_equal(
     assert segmentation_extractor1.get_num_rois() == segmentation_extractor2.get_num_rois()
     assert segmentation_extractor1.get_num_frames() == segmentation_extractor2.get_num_frames()
     assert segmentation_extractor1.get_num_channels() == segmentation_extractor2.get_num_channels()
-    assert np.isclose(segmentation_extractor1.get_sampling_frequency(), segmentation_extractor2.get_sampling_frequency())
+    assert np.isclose(
+        segmentation_extractor1.get_sampling_frequency(), segmentation_extractor2.get_sampling_frequency()
+    )
     assert_array_equal(segmentation_extractor1.get_channel_names(), segmentation_extractor2.get_channel_names())
     assert_array_equal(segmentation_extractor1.get_image_size(), segmentation_extractor2.get_image_size())
     assert_array_equal(

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -215,7 +215,7 @@ def check_segmentations_equal(
     assert_array_equal(segmentation_extractor1.get_roi_ids(), segmentation_extractor2.get_roi_ids())
     assert_array_equal(segmentation_extractor1.get_traces(), segmentation_extractor2.get_traces())
 
-    assert_array_equal(
+    assert_array_almost_equal(
         segmentation_extractor1.frame_to_time(np.arange(segmentation_extractor1.get_num_frames())),
         segmentation_extractor2.frame_to_time(np.arange(segmentation_extractor2.get_num_frames())),
     )

--- a/tests/test_internals/test_testing_tools.py
+++ b/tests/test_internals/test_testing_tools.py
@@ -32,7 +32,7 @@ class TestDummySegmentationExtractor(TestCase):
         assert segmentation_extractor.get_roi_locations().shape == (2, self.num_rois)
 
         # Test frame_to_time
-        times = np.round(np.arange(self.num_frames) / self.sampling_frequency, 6)
+        times = np.arange(self.num_frames) / self.sampling_frequency
         assert_array_equal(segmentation_extractor.frame_to_time(frames=np.arange(self.num_frames)), times)
         self.assertEqual(segmentation_extractor.frame_to_time(frames=8), times[8])
 


### PR DESCRIPTION
For fixing https://github.com/catalystneuro/neuroconv/pull/130 and also just ensuring a closer behavior of our timestamps to those found in SpikeInterface: https://github.com/catalystneuro/spikeinterface/blob/master/spikeinterface/core/baserecording.py#L448-L449