### PR TITLE
Add detector for if timestamps are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### Features
+
+* Added a `has_time_vector` function for ImagingExtractors and SegementationExtractors, similar to the SpikeInterface API for detecting if timestamps have been set. [PR #216](https://github.com/catalystneuro/roiextractors/pull/216)
+
 ### Fixes
 
 * Fixed two issues with the `SubFrameSegementation` class: (i) attempting to set the private attribute `_image_masks` even when this was not present in the parent, and (ii) not calling the parent function for `get_pixel_masks` and instead using the base method even in cases where this had been overridden by the parent. [PR #215](https://github.com/catalystneuro/roiextractors/pull/215)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-* Added a `has_time_vector` function for ImagingExtractors and SegementationExtractors, similar to the SpikeInterface API for detecting if timestamps have been set. [PR #216](https://github.com/catalystneuro/roiextractors/pull/216)
+* Added a `has_time_vector` function for ImagingExtractors and SegmentationExtractors, similar to the SpikeInterface API for detecting if timestamps have been set. [PR #216](https://github.com/catalystneuro/roiextractors/pull/216)
 
 ### Fixes
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -115,6 +115,10 @@ class ImagingExtractor(ABC):
         assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
         self._times = np.array(times).astype("float64")
 
+    def has_time_vector(self) -> None:
+        """Detect if the ImagingExtractor has a time vector set or not."""
+        return self._times is not None
+
     def copy_times(self, extractor) -> None:
         """This function copies times from another extractor.
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -115,7 +115,7 @@ class ImagingExtractor(ABC):
         assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
         self._times = np.array(times).astype("float64")
 
-    def has_time_vector(self) -> None:
+    def has_time_vector(self) -> bool:
         """Detect if the ImagingExtractor has a time vector set or not."""
         return self._times is not None
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -289,7 +289,7 @@ class SegmentationExtractor(ABC):
         assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
         self._times = np.array(times, dtype=np.float64)
 
-    def has_time_vector(self) -> None:
+    def has_time_vector(self) -> bool:
         """Detect if the SegmentationExtractor has a time vector set or not."""
         return self._times is not None
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -289,6 +289,10 @@ class SegmentationExtractor(ABC):
         assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
         self._times = np.array(times, dtype=np.float64)
 
+    def has_time_vector(self) -> None:
+        """Detect if the SegmentationExtractor has a time vector set or not."""
+        return self._times is not None
+
     def frame_to_time(self, frames: Union[IntType, ArrayType]) -> Union[FloatType, ArrayType]:
         """Returns the timing of frames in unit of seconds.
 

--- a/tests/test_internals/test_imaging_extractor.py
+++ b/tests/test_internals/test_imaging_extractor.py
@@ -1,0 +1,28 @@
+import unittest
+
+import numpy as np
+from hdmf.testing import TestCase
+
+from roiextractors.testing import generate_dummy_imaging_extractor
+
+
+class TestImagingExtractor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.imaging_extractor = generate_dummy_imaging_extractor(
+            num_frames=3, num_rows=2, num_columns=4, sampling_frequency=20.0
+        )
+
+    def test_has_time_vector_true(self):
+        imaging_extractor_with_times = generate_dummy_imaging_extractor(
+            num_frames=3, num_rows=3, num_columns=4, sampling_frequency=20.0
+        )
+        imaging_extractor_with_times.set_times(times=np.array([1.1, 2.3, 3.7]))
+        self.assertTrue(imaging_extractor_with_times.has_time_vector())
+
+    def test_has_time_vector_false(self):
+        self.assertFalse(self.imaging_extractor.has_time_vector())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internals/test_segmentation_extractor.py
+++ b/tests/test_internals/test_segmentation_extractor.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+from hdmf.testing import TestCase
+
+from roiextractors.testing import generate_dummy_segmentation_extractor
+
+
+class TestSegmentationExtractor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.segmentation_extractor = generate_dummy_segmentation_extractor(num_frames=3, num_rows=2, num_columns=4)
+
+    def test_has_time_vector_true(self):
+        segmentation_extractor_with_times = generate_dummy_segmentation_extractor(
+            num_frames=3, num_rows=3, num_columns=4, sampling_frequency=20.0
+        )
+        segmentation_extractor_with_times.set_times(times=np.array([1.1, 2.3, 3.7]))
+        self.assertTrue(segmentation_extractor_with_times.has_time_vector())
+
+    def test_has_time_vector_false(self):
+        self.assertFalse(self.segmentation_extractor.has_time_vector())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Needed for fixing the new issue on https://github.com/catalystneuro/neuroconv/pull/159

Follows API pattern established by SpikeInterface: https://github.com/SpikeInterface/spikeinterface/blob/master/spikeinterface/core/baserecording.py#L171-L178

Also added a new portion to the testing suite for base classes, which could be filled out more in the future