### PR TITLE
add `BrukerTiffImagingExtractor`

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,2 +1,2 @@
-tifffile==2018.10.18
+tifffile>=2018.10.18
 scanimage-tiff-reader==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if not gin_config_file_local.exists():
 
 setup(
     name="roiextractors",
-    version="0.5.0",
+    version="0.5.1",
     author="Heberto Mayorquin, Cody Baker, Ben Dichter, Alessio Buccino",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if not gin_config_file_local.exists():
 
 setup(
     name="roiextractors",
-    version="0.5.1",
+    version="0.5.2",
     author="Heberto Mayorquin, Cody Baker, Ben Dichter, Alessio Buccino",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",

--- a/src/roiextractors/extractorlist.py
+++ b/src/roiextractors/extractorlist.py
@@ -12,7 +12,11 @@ from .extractors.schnitzerextractor import (
 )
 from .extractors.simaextractor import SimaSegmentationExtractor
 from .extractors.suite2p import Suite2pSegmentationExtractor
-from .extractors.tiffimagingextractors import TiffImagingExtractor, ScanImageTiffImagingExtractor
+from .extractors.tiffimagingextractors import (
+    TiffImagingExtractor,
+    ScanImageTiffImagingExtractor,
+    BrukerTiffImagingExtractor,
+)
 from .extractors.sbximagingextractor import SbxImagingExtractor
 from .extractors.memmapextractors import NumpyMemmapImagingExtractor
 from .extractors.memmapextractors import MemmapImagingExtractor
@@ -24,6 +28,7 @@ imaging_extractor_full_list = [
     Hdf5ImagingExtractor,
     TiffImagingExtractor,
     ScanImageTiffImagingExtractor,
+    BrukerTiffImagingExtractor,
     NwbImagingExtractor,
     SbxImagingExtractor,
     NumpyMemmapImagingExtractor,

--- a/src/roiextractors/extractors/tiffimagingextractors/__init__.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/__init__.py
@@ -1,2 +1,3 @@
 from .tiffimagingextractor import TiffImagingExtractor
 from .scanimagetiffimagingextractor import ScanImageTiffImagingExtractor
+from .brukertiffimagingextractor import BrukerTiffImagingExtractor

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -112,8 +112,10 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
         start_frame: Optional[int] = None,
         end_frame: Optional[int] = None,
     ):
+        tiffile = get_package(package_name="tifffile", installation_instructions="pip install tifffile")
+
         for file in self._file_paths[start_frame:end_frame]:
-            yield _get_tiff_reader().memmap(self.folder_path / file, mode="r", _multifile=False)
+            yield tiffile.memmap(self.folder_path / file, mode="r", _multifile=False)
 
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -52,10 +52,16 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
         tif_file_paths = list(self.folder_path.glob("*.ome.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{self.folder_path}'."
         if num_sequences != 1:
-            missing_files = [file_path for file_path in self._file_paths if self.folder_path / file_path not in tif_file_paths]
-            assert not missing_files, f"Some of the TIF image files at '{self.folder_path}' are missing for this plane. The list of files that are missing: {missing_files}"
+            missing_files = [
+                file_path for file_path in self._file_paths if self.folder_path / file_path not in tif_file_paths
+            ]
+            assert (
+                not missing_files
+            ), f"Some of the TIF image files at '{self.folder_path}' are missing for this plane. The list of files that are missing: {missing_files}"
         else:
-            assert len(self._file_paths) == len(tif_file_paths), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
+            assert len(self._file_paths) == len(
+                tif_file_paths
+            ), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
 
         with tifffile.TiffFile(self.folder_path / self._file_paths[0], _multifile=False) as tif:
             self._height, self._width = tif.pages.first.shape

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -67,8 +67,8 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
         tif_file_paths = list(self.folder_path.glob("*.ome.tif"))
 
         assert len(self._file_paths) == len(
-                tif_file_paths
-            ), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
+            tif_file_paths
+        ), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
 
         with tifffile.TiffFile(self.folder_path / self._file_paths[0], _multifile=False) as tif:
             self._height, self._width = tif.pages.first.shape
@@ -163,9 +163,9 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
             yield tifffile.memmap(self.folder_path / file, mode="r", _multifile=False)
 
     def _get_video_for_multi_z_planes(
-            self,
-            start_frame: Optional[int] = None,
-            end_frame: Optional[int] = None,
+        self,
+        start_frame: Optional[int] = None,
+        end_frame: Optional[int] = None,
     ) -> np.ndarray:
         tifffile = _get_tiff_reader()
 

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -67,8 +67,8 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
             ), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
 
         with self._tifffile.TiffFile(self.folder_path / self._file_paths[0], _multifile=False) as tif:
-            self._height, self._width = tif.pages.first.shape
-            self._dtype = tif.pages.first.dtype
+            self._height, self._width = tif.pages[0].shape
+            self._dtype = tif.pages[0].dtype
 
         self.xml_metadata = self._get_xml_metadata()
         self._sampling_frequency = 1 / float(self.xml_metadata["framePeriod"])

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -1,0 +1,123 @@
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Optional, Tuple
+from xml.etree import ElementTree
+
+import numpy as np
+
+from ...imagingextractor import ImagingExtractor
+from ...extraction_tools import PathType, get_package, DtypeType, FloatType
+
+
+def filter_read_uic_tag_warnings(record):
+    return not record.msg.startswith("<tifffile.read_uic_tag>")
+
+
+logging.getLogger("tifffile.tifffile").addFilter(filter_read_uic_tag_warnings)
+
+
+def _get_tiff_reader() -> ModuleType:
+    return get_package(package_name="tifffile", installation_instructions="pip install tifffile")
+
+
+class BrukerTiffImagingExtractor(ImagingExtractor):
+    extractor_name = "BrukerTiffImaging"
+    is_writable = True
+    mode = "folder"
+
+    def __init__(self, folder_path: PathType, sampling_frequency: Optional[FloatType] = None):
+        tifffile = _get_tiff_reader()
+
+        super().__init__()
+        self.folder_path = Path(folder_path)
+        self._sampling_frequency = sampling_frequency
+        self.xml_metadata = self._get_xml_metadata()
+        self._file_paths = self._get_files_names()
+        assert list(self.folder_path.glob("*.ome.tif")), f"The TIF image files are missing from '{self.folder_path}'."
+        assert len(self._file_paths) == len(
+            list(self.folder_path.glob("*.ome.tif"))
+        ), f"The number of TIF image files at '{self.folder_path}' should be equal to the number of frames ({len(self._file_paths)}) specified in the XML configuration file."
+
+        with tifffile.TiffFile(self.folder_path / self._file_paths[0], _multifile=False) as tif:
+            self._height, self._width = tif.pages.first.shape
+            self._dtype = tif.pages.first.dtype
+
+    def _get_xml_root(self):
+        xml_file_path = self.folder_path / f"{self.folder_path.stem}.xml"
+        assert Path(xml_file_path).is_file(), f"The XML configuration file is not found at '{self.folder_path}'."
+        tree = ElementTree.parse(xml_file_path)
+        return tree.getroot()
+
+    def _get_xml_metadata(self):
+        root = self._get_xml_root()
+        xml_metadata = dict()
+        xml_metadata.update(**root.attrib)
+        for child in root.findall(".//PVStateValue"):
+            metadata_root_key = child.attrib["key"]
+            if "value" in child.attrib:
+                if metadata_root_key in xml_metadata:
+                    continue
+                xml_metadata[metadata_root_key] = child.attrib["value"]
+            else:
+                xml_metadata[metadata_root_key] = []
+                for indexed_value in child:
+                    if "value" not in indexed_value.attrib:
+                        for subindexed_value in indexed_value:
+                            if "description" in subindexed_value.attrib:
+                                xml_metadata[metadata_root_key].append(
+                                    {subindexed_value.attrib["description"]: subindexed_value.attrib["value"]}
+                                )
+                            else:
+                                xml_metadata[child.attrib["key"]].append(
+                                    {indexed_value.attrib["index"]: subindexed_value.attrib["value"]}
+                                )
+                    if "description" in indexed_value.attrib:
+                        xml_metadata[child.attrib["key"]].append(
+                            {indexed_value.attrib["description"]: indexed_value.attrib["value"]}
+                        )
+                    elif "value" in indexed_value.attrib:
+                        xml_metadata[child.attrib["key"]].append(
+                            {indexed_value.attrib["index"]: indexed_value.attrib["value"]}
+                        )
+        return xml_metadata
+
+    def _get_files_names(self):
+        return [file.attrib["filename"] for file in self._get_xml_root().findall(".//File")]
+
+    def get_image_size(self) -> Tuple[int, int]:
+        return self._height, self._width
+
+    def get_num_frames(self) -> int:
+        return len(self._file_paths)
+
+    def get_sampling_frequency(self) -> float:
+        frame_period = float(self.xml_metadata["framePeriod"])
+        return 1 / frame_period
+
+    def get_channel_names(self) -> list:
+        channel_names = [file.attrib["channelName"] for file in self._get_xml_root().findall(".//File")]
+        unique_channel_names = list(set(channel_names))
+        return unique_channel_names
+
+    def get_num_channels(self) -> int:
+        channel_names = self.get_channel_names()
+        return len(channel_names)
+
+    def get_dtype(self) -> DtypeType:
+        return self._dtype
+
+    def _frames_iterator(
+        self,
+        start_frame: Optional[int] = None,
+        end_frame: Optional[int] = None,
+    ):
+        for file in self._file_paths[start_frame:end_frame]:
+            yield _get_tiff_reader().memmap(self.folder_path / file, mode="r", _multifile=False)
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        frames = list(self._frames_iterator(start_frame=start_frame, end_frame=end_frame))
+        video = np.stack(frames, axis=0)
+        return video

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree
 import numpy as np
 
 from ...imagingextractor import ImagingExtractor
-from ...extraction_tools import PathType, get_package, DtypeType, FloatType
+from ...extraction_tools import PathType, get_package, DtypeType
 
 
 def filter_read_uic_tag_warnings(record):
@@ -113,6 +113,10 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
         end_frame: Optional[int] = None,
     ):
         tiffile = _get_tiff_reader()
+
+        if start_frame is not None and end_frame is not None:
+            if end_frame == start_frame:
+                yield tiffile.memmap(self.folder_path / self._file_paths[start_frame], mode="r", _multifile=False)
 
         for file in self._file_paths[start_frame:end_frame]:
             yield tiffile.memmap(self.folder_path / file, mode="r", _multifile=False)

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from types import ModuleType
-from typing import Optional, Tuple, Union, List, Iterable
+from typing import Optional, Tuple, Union, List, Iterable, Dict
 from xml.etree import ElementTree
 
 import numpy as np
@@ -83,7 +83,7 @@ class BrukerTiffImagingExtractor(ImagingExtractor):
         tree = ElementTree.parse(xml_file_path)
         return tree.getroot()
 
-    def _get_xml_metadata(self) -> dict[str, Union[str, List[dict[str, str]]]]:
+    def _get_xml_metadata(self) -> Dict[str, Union[str, List[Dict[str, str]]]]:
         """
         Parses the metadata in the root element that are under "PVStateValue" tag into
         a dictionary.

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -34,6 +34,11 @@ class TestBrukerTiffExtractor(TestCase):
         cls.test_dir = test_dir
         shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
 
+    @classmethod
+    def tearDownClass(cls):
+        # remove the temporary directory and its contents
+        shutil.rmtree(cls.test_dir)
+
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"
         exc_msg = f"The TIF image files are missing from '{folder_path}'."

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -6,14 +6,14 @@ from numpy.testing import assert_array_equal
 from tifffile import tifffile
 
 from roiextractors import BrukerTiffImagingExtractor
-#from tests.setup_paths import OPHYS_DATA_PATH
+from tests.setup_paths import OPHYS_DATA_PATH
 
 
 class TestBrukerTiffExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
         folder_path = str(
-            "/Users/weian/ophys_testing_data/imaging_datasets/BrukerTif/NCCR32_2023_02_20_Into_the_void_t_series_baseline-000"
+            OPHYS_DATA_PATH / "imaging_datasets" / "BrukerTif" / "NCCR32_2023_02_20_Into_the_void_t_series_baseline-000"
         )
 
         cls.folder_path = folder_path

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import numpy as np
+from hdmf.testing import TestCase
+from numpy.testing import assert_array_equal
+from tifffile import tifffile
+
+from roiextractors import BrukerTiffImagingExtractor
+from tests.setup_paths import OPHYS_DATA_PATH
+
+
+class TestBrukerTiffExtractor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        folder_path = str(
+            OPHYS_DATA_PATH / "imaging_datasets" / "Brukertif" / "NCCR32_2023_02_20_Into_the_void_t_series_baseline-000"
+        )
+
+        cls.folder_path = folder_path
+        extractor = BrukerTiffImagingExtractor(folder_path=folder_path)
+        cls.extractor = extractor
+
+        frames = []
+        for file in extractor._file_paths:
+            with tifffile.TiffFile(Path(folder_path) / file, _multifile=False) as tif:
+                frames.append(tif.asarray())
+        cls.video = np.stack(frames, axis=0)
+
+    def test_tif_files_are_missing_assertion(self):
+        folder_path = "not a tiff path"
+        exc_msg = f"The TIF image files are missing from '{folder_path}'."
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            BrukerTiffImagingExtractor(folder_path=folder_path)
+
+    # TODO: create temporary folder, without xml and test on that folder
+    # def test_xml_configuration_file_is_missing_assertion(self):
+    #     folder_path = "/Volumes/t7-ssd/Pinto/brukertiff/test_no_xml"
+    #     exc_msg = f"The XML configuration file is not found at '{folder_path}'."
+    #     with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+    #         BrukerTiffImagingExtractor(folder_path=folder_path)
+
+    def test_brukertiffextractor_image_size(self):
+        self.assertEqual(self.extractor.get_image_size(), (512, 512))
+
+    def test_brukertiffextractor_num_frames(self):
+        self.assertEqual(self.extractor.get_num_frames(), 10)
+
+    def test_brukertiffextractor_sampling_frequency(self):
+        self.assertEqual(self.extractor.get_sampling_frequency(), 30.345939461428763)
+
+    def test_brukertiffextractor_channel_names(self):
+        self.assertEqual(self.extractor.get_channel_names(), ["Ch2"])
+
+    def test_brukertiffextractor_num_channels(self):
+        self.assertEqual(self.extractor.get_num_channels(), 1)
+
+    def test_brukertiffextractor_dtype(self):
+        self.assertEqual(self.extractor.get_dtype(), np.uint16)
+
+    def test_brukertiffextractor_get_video(self):
+        assert_array_equal(self.extractor.get_video(), self.video)
+
+    def test_brukertiffextractor_get_video_multi_channel_assertion(self):
+        exc_msg = "The BrukerTiffImagingExtractor does not currently support multiple color channels."
+        with self.assertRaisesWith(NotImplementedError, exc_msg=exc_msg):
+            self.extractor.get_video(channel=1)
+
+    def test_brukertiffextractor_xml_metadata(self):
+        xml_metadata = self.extractor.xml_metadata
+
+        self.assertEqual(xml_metadata["version"], "5.6.64.400")
+        self.assertEqual(xml_metadata["date"], "2/20/2023 3:58:25 PM")
+        self.assertEqual(xml_metadata["framePeriod"], "0.032953338")
+        self.assertEqual(xml_metadata["micronsPerPixel"], [{"XAxis": "1.1078125"}, {"YAxis": "1.1078125"}, {"ZAxis": "5"}])

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -6,14 +6,14 @@ from numpy.testing import assert_array_equal
 from tifffile import tifffile
 
 from roiextractors import BrukerTiffImagingExtractor
-from tests.setup_paths import OPHYS_DATA_PATH
+#from tests.setup_paths import OPHYS_DATA_PATH
 
 
 class TestBrukerTiffExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
         folder_path = str(
-            OPHYS_DATA_PATH / "imaging_datasets" / "BrukerTif" / "NCCR32_2023_02_20_Into_the_void_t_series_baseline-000"
+            "/Users/weian/ophys_testing_data/imaging_datasets/BrukerTif/NCCR32_2023_02_20_Into_the_void_t_series_baseline-000"
         )
 
         cls.folder_path = folder_path
@@ -59,6 +59,9 @@ class TestBrukerTiffExtractor(TestCase):
 
     def test_brukertiffextractor_get_video(self):
         assert_array_equal(self.extractor.get_video(), self.video)
+
+    def test_brukertiffextractor_get_single_frame(self):
+        assert_array_equal(self.extractor.get_frames(frame_idxs=[0]), self.video[0][np.newaxis, ...])
 
     def test_brukertiffextractor_get_video_multi_channel_assertion(self):
         exc_msg = "The BrukerTiffImagingExtractor does not currently support multiple color channels."


### PR DESCRIPTION
Add support for Bruker 2P imaging data which consists of:
- individual TIFF files in `OME-TIF` format (`.ome.tif` files) where each TIFF file corresponds to a single frame
- metadata in XML format (`.xml` and `.env` files)

The metadata from the .xml file in dict form for reference:
```python
{
'version': '5.6.64.400',
'date': '2/20/2023 3:58:25 PM',
'notes': '',
'activeMode': 'ResonantGalvo',
'bitDepth': '13',
'currentScanAmplitude': [{'XAxis': '4.17170481'}, {'YAxis': '4.17170481'}],
'currentScanCenter': [{'XAxis': '0'}, {'YAxis': '0'}],
'dwellTime': '0.4',
'framePeriod': '0.032953338',
'interlacedScanTrackCount': '0',
'laserPower': [{'920 Axon': '500'}, {'1064 Axon': '900.390625'}, {'Monaco': '0'}],
'linesPerFrame': '512',
'maxVoltage': [{'XAxis': '2.085852405'}, {'YAxis': '2.085852405'}],
'micronsPerPixel': [{'XAxis': '1.1078125'}, {'YAxis': '1.1078125'}, {'ZAxis': '5'}],
'minVoltage': [{'XAxis': '-2.085852405'}, {'YAxis': '-2.085852405'}],
'objectiveLens': '16X', 'objectiveLensMag': '16', 'objectiveLensNA': '0.8',
'opticalZoom': '2',
'pixelsPerLine': '512',
'pmtGain': [{'PMT 1 HV (Red)': '800'}, {'PMT 2 HV (Green)': '700'}],
'positionCurrent': [{'XAxis': '0'}, {'YAxis': '0'}, {'Z Focus': '147.55'},
                     {'Optotune ETL 10-30': '-80.0653860309135'}],
 'preampFilter': 'NoFilter',
 'preampOffset': [{'Ch1': '0'}, {'Ch2': '0'}],
 'rastersPerFrame': '1',
 'rotation': '0',
 'samplesPerPixel': '3',
 'scanLinePeriod': '6.3129E-05',
 'useInterlacedScanPattern': 'False',
 'xYStageGridIndex': '-1', 'xYStageGridXIndex': '-1', 'xYStageGridYIndex': '-1',
 'yAspectExpansion': '1', 'zDevice': '0'}
```