### PR TITLE
Add `MicroManagerTiffImagingExtractor`

### DIFF
--- a/src/roiextractors/extractorlist.py
+++ b/src/roiextractors/extractorlist.py
@@ -12,7 +12,11 @@ from .extractors.schnitzerextractor import (
 )
 from .extractors.simaextractor import SimaSegmentationExtractor
 from .extractors.suite2p import Suite2pSegmentationExtractor
-from .extractors.tiffimagingextractors import TiffImagingExtractor, ScanImageTiffImagingExtractor
+from .extractors.tiffimagingextractors import (
+    TiffImagingExtractor,
+    ScanImageTiffImagingExtractor,
+    MicroManagerTiffImagingExtractor,
+)
 from .extractors.sbximagingextractor import SbxImagingExtractor
 from .extractors.memmapextractors import NumpyMemmapImagingExtractor
 from .extractors.memmapextractors import MemmapImagingExtractor
@@ -24,6 +28,7 @@ imaging_extractor_full_list = [
     Hdf5ImagingExtractor,
     TiffImagingExtractor,
     ScanImageTiffImagingExtractor,
+    MicroManagerTiffImagingExtractor,
     NwbImagingExtractor,
     SbxImagingExtractor,
     NumpyMemmapImagingExtractor,

--- a/src/roiextractors/extractors/tiffimagingextractors/__init__.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/__init__.py
@@ -1,2 +1,3 @@
 from .tiffimagingextractor import TiffImagingExtractor
 from .scanimagetiffimagingextractor import ScanImageTiffImagingExtractor
+from .micromanagertiffimagingextractor import MicroManagerTiffImagingExtractor

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 from collections import Counter
-from encodings.utf_8 import decode
 from itertools import islice
 from pathlib import Path
 from types import ModuleType

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -15,6 +15,13 @@ from ...extraction_tools import PathType, get_package, DtypeType
 from ...multiimagingextractor import MultiImagingExtractor
 
 
+def filter_tiff_tag_warnings(record):
+    return not record.msg.startswith("<tifffile.TiffTag 270 @42054>")
+
+
+logging.getLogger("tifffile.tifffile").addFilter(filter_tiff_tag_warnings)
+
+
 def _get_tiff_reader() -> ModuleType:
     return get_package(package_name="tifffile", installation_instructions="pip install tifffile")
 

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -48,8 +48,6 @@ class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
         first_tif = self.tifffile.TiffFile(self._ome_tif_files[0])
         # extract metadata from Micro-Manager
         micromanager_metadata = first_tif.micromanager_metadata
-        if micromanager_metadata is None or "Summary" not in micromanager_metadata:
-            micromanager_metadata = first_tif.pages[0].tags["MicroManagerMetadata"].value
         assert "Summary" in micromanager_metadata, "The 'Summary' field is not found in Micro-Manager metadata."
         self.micromanager_metadata = micromanager_metadata
         self._width = self.micromanager_metadata["Summary"]["Width"]

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -1,0 +1,182 @@
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+from typing import Optional, Tuple
+
+from xml.etree import ElementTree
+import numpy as np
+
+from ...imagingextractor import ImagingExtractor
+from ...extraction_tools import PathType, get_package, DtypeType
+from ...multiimagingextractor import MultiImagingExtractor
+
+
+def _get_tiff_reader() -> ModuleType:
+    return get_package(package_name="tifffile", installation_instructions="pip install tifffile")
+
+
+class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
+    extractor_name = "MicroManagerTiffImaging"
+    installed = True
+    installation_mesg = ""
+
+    def __init__(self, folder_path: PathType):
+        """
+        The imaging extractor for the Micro-Manager TIF image format.
+        This format consists of multiple TIF image files in multipage OME-TIF format (.ome.tif files)
+        and 'DisplaySettings' JSON file.
+
+        Parameters
+        ----------
+        folder_path: PathType
+           The folder path that contains the multipage OME-TIF image files (.ome.tif files) and
+           the 'DisplaySettings' JSON file.
+        """
+        self.tifffile = _get_tiff_reader()
+        self.folder_path = Path(folder_path)
+
+        ome_tif_files = list(self.folder_path.glob("*.ome.tif"))
+        assert ome_tif_files, f"The TIF image files are missing from '{folder_path}'."
+
+        # load the 'DisplaySettings.json' file that contains the sampling frequency of images
+        settings = self._load_settings_json()
+        self._sampling_frequency = float(settings["map"]["PlaybackFPS"]["scalar"])
+
+        # load the first tif
+        first_tif = self.tifffile.TiffFile(self.folder_path / ome_tif_files[0])
+
+        # extract metadata from Micro-Manager
+        self.micromanager_metadata = first_tif.micromanager_metadata
+        self._width = self.micromanager_metadata["Summary"]["Width"]
+        self._height = self.micromanager_metadata["Summary"]["Height"]
+        self._num_channels = self.micromanager_metadata["Summary"]["Channels"]
+        self._channel_names = self.micromanager_metadata["Summary"]["ChNames"]
+
+        # extact metadata from OME XML
+        self._ome_metadata = first_tif.ome_metadata
+        ome_metadata_root = self._get_ome_xml_root()
+
+        schema_name = re.findall("\{(.*)\}", ome_metadata_root.tag)[0]
+        pixels_element = ome_metadata_root.find(f"{{{schema_name}}}Image/{{{schema_name}}}Pixels")
+        self._num_frames = int(pixels_element.attrib["SizeT"])
+        self._dtype = np.dtype(pixels_element.attrib["Type"])
+
+        # all the file names are repeated under the TiffData tag
+        # the number of occurences of each file path corresponds to the number of frames for a given TIF file
+        tiff_data_elements = pixels_element.findall(f"{{{schema_name}}}TiffData")
+        file_names = [element[0].attrib["FileName"] for element in tiff_data_elements]
+
+        # count the number of occurrences of each file path and their names
+        file_counts = Counter(file_names)
+        # Initialize the private imaging extractors with the number of frames for each file
+        imaging_extractors = []
+        # TODO make sure Counter returns the right order of image files
+        for file_path, num_frames_per_file in file_counts.items():
+            extractor = _SubMicroManagerTiffImagingExtractor(self.folder_path / file_path)
+            extractor._num_frames = num_frames_per_file
+            imaging_extractors.append(extractor)
+        super().__init__(imaging_extractors=imaging_extractors)
+
+    def _load_settings_json(self):
+        file_name = "DisplaySettings.json"
+        settings_json_file_path = self.folder_path / file_name
+        assert settings_json_file_path.exists(), f"'{file_name}' file not found at '{self.folder_path}'."
+
+        with open(settings_json_file_path, "r") as f:
+            settings = json.load(f)
+        return settings
+
+    def _get_ome_xml_root(self):
+        """
+        Parses the OME-XML configuration from string format into element tree and returns the root of this tree.
+        """
+        ome_metadata_element = ElementTree.fromstring(self._ome_metadata)
+        tree = ElementTree.ElementTree(ome_metadata_element)
+        return tree.getroot()
+
+    def _check_consistency_between_imaging_extractors(self):
+        """Overrides the parent class method as none of the properties that are checked are from the sub-imaging extractors."""
+        return True
+
+    def get_image_size(self) -> Tuple[int, int]:
+        return self._height, self._width
+
+    def get_sampling_frequency(self) -> float:
+        return self._sampling_frequency
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_channel_names(self) -> list:
+        return self._channel_names
+
+    def get_num_channels(self) -> int:
+        return self._num_channels
+
+    def get_dtype(self) -> DtypeType:
+        return self._dtype
+
+
+class _SubMicroManagerTiffImagingExtractor(ImagingExtractor):
+    extractor_name = "_SubMicroManagerTiffImaging"
+    is_writable = True
+    mode = "file"
+
+    IMAGE_SIZE_ERROR = "The {}Extractor does not support retrieving the image size."
+    SAMPLING_FREQ_ERROR = "The {}Extractor does not support retrieving the imaging rate."
+    CHANNEL_NAMES_ERROR = "The {}Extractor does not support retrieving the name of the channels."
+    DATA_TYPE_ERROR = "The {}Extractor does not support retrieving the data type."
+
+    def __init__(self, file_path: PathType):
+        """
+        The private imaging extractor for the WideField OME-TIF image format.
+        This extractor is not meant to be used as a standalone ImagingExtractor.
+        TODO: more explanation
+
+        Parameters
+        ----------
+        file_path : PathType
+            The path to the TIF image file (.ome.tif)
+        """
+        self.tifffile = _get_tiff_reader()
+        self.file_path = file_path
+
+        super().__init__()
+
+        self.pages = self.tifffile.TiffFile(self.file_path).pages
+        self._num_frames = None
+
+    def get_num_frames(self):
+        return self._num_frames
+
+    def get_num_channels(self) -> int:
+        return 1
+
+    def get_image_size(self):
+        raise NotImplementedError(self.IMAGE_SIZE_ERROR.format(self.extractor_name))
+
+    def get_sampling_frequency(self):
+        raise NotImplementedError(self.SAMPLING_FREQ_ERROR.format(self.extractor_name))
+
+    def get_channel_names(self) -> list:
+        raise NotImplementedError(self.CHANNEL_NAMES_ERROR.format(self.extractor_name))
+
+    def get_dtype(self):
+        raise NotImplementedError(self.DATA_TYPE_ERROR.format(self.extractor_name))
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        if channel != 0:
+            raise NotImplementedError(
+                f"The {self.extractor_name}Extractor does not currently support multiple color channels."
+            )
+        if start_frame is not None and end_frame is not None and start_frame == end_frame:
+            page = self.pages[start_frame]
+            return page.asarray()[np.newaxis, ...]
+
+        pages = self.pages[start_frame:end_frame]
+        frames = [page.asarray() for page in pages]
+        return np.stack(frames)

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -19,17 +19,8 @@ def _get_tiff_reader() -> ModuleType:
     return get_package(package_name="tifffile", installation_instructions="pip install tifffile")
 
 
-def filter_tiff_tag_warnings(record):
-    return not record.msg.startswith("<tifffile.TiffTag 270 @42054>")
-
-
-logging.getLogger("tifffile.tifffile").addFilter(filter_tiff_tag_warnings)
-
-
 class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
     extractor_name = "MicroManagerTiffImaging"
-    installed = True
-    installation_mesg = ""
 
     def __init__(self, folder_path: PathType):
         """
@@ -102,7 +93,7 @@ class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
         """
         file_name = "DisplaySettings.json"
         settings_json_file_path = self.folder_path / file_name
-        assert settings_json_file_path.exists(), f"'{file_name}' file not found at '{self.folder_path}'."
+        assert settings_json_file_path.exists(), f"The '{file_name}' file is not found at '{self.folder_path}'."
 
         with open(settings_json_file_path, "r") as f:
             settings = json.load(f)
@@ -202,10 +193,6 @@ class _MicroManagerTiffImagingExtractor(ImagingExtractor):
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
     ) -> np.ndarray:
-        if channel != 0:
-            raise NotImplementedError(
-                f"The {self.extractor_name}Extractor does not currently support multiple color channels."
-            )
         if start_frame is not None and end_frame is not None and start_frame == end_frame:
             return self.pages[start_frame].asarray()
 

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -127,7 +127,7 @@ class MultiImagingExtractor(ImagingExtractor):
                 start_frame=relative_start, end_frame=relative_stop
             )
 
-        video_shape = (stop - start,) + self._imaging_extractors[0].get_image_size()
+        video_shape = (stop - start,) + self.get_image_size()
         video = np.empty(shape=video_shape, dtype=self.get_dtype())
         current_frame = 0
 

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -127,7 +127,7 @@ class MultiImagingExtractor(ImagingExtractor):
                 start_frame=relative_start, end_frame=relative_stop
             )
 
-        video_shape = (stop - start,) + self.get_image_size()
+        video_shape = (stop - start,) + self._imaging_extractors[0].get_image_size()
         video = np.empty(shape=video_shape, dtype=self.get_dtype())
         current_frame = 0
 

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -28,14 +28,8 @@ class TestMicroManagerTiffExtractor(TestCase):
 
         # temporary directory for testing assertion when xml file is missing
         test_dir = tempfile.mkdtemp()
-        cls.test_dir_1 = test_dir
+        cls.test_dir = test_dir
         shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
-
-        # temporary directory for testing when some of the files are missing
-        test_dir = tempfile.mkdtemp()
-        cls.test_dir_2 = test_dir
-        shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
-        shutil.copy(Path(folder_path) / "DisplaySettings.json", Path(test_dir) / "DisplaySettings.json")
 
     @classmethod
     def _get_test_video(cls):
@@ -47,8 +41,7 @@ class TestMicroManagerTiffExtractor(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.test_dir_1)
-        shutil.rmtree(cls.test_dir_2)
+        shutil.rmtree(cls.test_dir)
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"
@@ -57,14 +50,16 @@ class TestMicroManagerTiffExtractor(TestCase):
             MicroManagerTiffImagingExtractor(folder_path=folder_path)
 
     def test_json_file_is_missing_assertion(self):
-        exc_msg = f"The 'DisplaySettings.json' file is not found at '{self.test_dir_1}'."
+        folder_path = self.test_dir
+        exc_msg = f"The 'DisplaySettings.json' file is not found at '{folder_path}'."
         with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
-            MicroManagerTiffImagingExtractor(folder_path=self.test_dir_1)
+            MicroManagerTiffImagingExtractor(folder_path=folder_path)
 
     def test_list_of_missing_tif_files_assertion(self):
-        exc_msg = f"Some of the TIF image files at '{self.test_dir_2}' are missing. The list of files that are missing: {self.file_paths[1:]}"
+        shutil.copy(Path(self.folder_path) / "DisplaySettings.json", Path(self.test_dir) / "DisplaySettings.json")
+        exc_msg = f"Some of the TIF image files at '{self.test_dir}' are missing. The list of files that are missing: {self.file_paths[1:]}"
         with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
-            MicroManagerTiffImagingExtractor(folder_path=self.test_dir_2)
+            MicroManagerTiffImagingExtractor(folder_path=self.test_dir)
 
     def test_micromanagertiffextractor_image_size(self):
         self.assertEqual(self.extractor.get_image_size(), (1024, 1024))

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -43,10 +43,9 @@ class TestMicroManagerTiffExtractor(TestCase):
     @classmethod
     def tearDownClass(cls):
         try:
-            (Path(cls.test_dir) / cls.file_paths[0]).unlink()
             shutil.rmtree(cls.test_dir)
         except PermissionError:  # Windows
-            warn(f"Unable to cleanup testing data at {cls.test_dir / cls.file_paths[0]}! Please remove them manually.")
+            warn(f"Unable to cleanup testing data at {cls.test_dir}! Please remove it manually.")
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -41,6 +41,7 @@ class TestMicroManagerTiffExtractor(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        Path(cls.folder_path / cls.file_paths[0]).unlink()
         shutil.rmtree(cls.test_dir)
 
     def test_tif_files_are_missing_assertion(self):

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -46,9 +46,7 @@ class TestMicroManagerTiffExtractor(TestCase):
             (Path(cls.test_dir) / cls.file_paths[0]).unlink()
             shutil.rmtree(cls.test_dir)
         except PermissionError:  # Windows
-            warn(
-                f"Unable to cleanup testing data at {cls.test_dir / cls.file_paths[0]}! Please remove them manually."
-            )
+            warn(f"Unable to cleanup testing data at {cls.test_dir / cls.file_paths[0]}! Please remove them manually.")
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -55,6 +55,12 @@ class TestMicroManagerTiffExtractor(TestCase):
         with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
             MicroManagerTiffImagingExtractor(folder_path=folder_path)
 
+    def test_list_of_missing_tif_files_assertion(self):
+        shutil.copy(Path(self.folder_path) / "DisplaySettings.json", Path(self.test_dir) / "DisplaySettings.json")
+        exc_msg = f"Some of the TIF image files at '{self.test_dir}' are missing. The list of files that are missing: {self.file_paths[1:]}"
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            MicroManagerTiffImagingExtractor(folder_path=self.test_dir)
+
     def test_micromanagertiffextractor_image_size(self):
         self.assertEqual(self.extractor.get_image_size(), (1024, 1024))
 

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -14,9 +14,7 @@ from tests.setup_paths import OPHYS_DATA_PATH
 class TestMicroManagerTiffExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
-        folder_path = str(
-            OPHYS_DATA_PATH / "imaging_datasets" / "MicroManagerTif" / "TS12_20220407_20hz_noteasy_1"
-        )
+        folder_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "MicroManagerTif" / "TS12_20220407_20hz_noteasy_1")
         cls.folder_path = Path(folder_path)
         file_paths = [
             "TS12_20220407_20hz_noteasy_1_MMStack_Default.ome.tif",
@@ -45,7 +43,7 @@ class TestMicroManagerTiffExtractor(TestCase):
     def tearDownClass(cls):
         pass
         # remove the temporary directory and its contents
-        #shutil.rmtree(cls.test_dir)
+        # shutil.rmtree(cls.test_dir)
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"
@@ -81,5 +79,4 @@ class TestMicroManagerTiffExtractor(TestCase):
         assert_array_equal(self.extractor.get_video(), self.video)
 
     def test_brukertiffextractor_get_single_frame(self):
-        assert_array_equal(self.extractor.get_frames(frame_idxs=[0]),
-                           self.video[0][np.newaxis, ...])
+        assert_array_equal(self.extractor.get_frames(frame_idxs=[0]), self.video[0][np.newaxis, ...])

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -45,7 +45,9 @@ class TestMicroManagerTiffExtractor(TestCase):
             Path(cls.folder_path / cls.file_paths[0]).unlink()
             shutil.rmtree(cls.test_dir)
         except PermissionError:  # Windows
-            warn(f"Unable to cleanup testing data at {cls.folder_path / cls.file_paths[0]}! Please remove them manually.")
+            warn(
+                f"Unable to cleanup testing data at {cls.folder_path / cls.file_paths[0]}! Please remove them manually."
+            )
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -1,0 +1,85 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from hdmf.testing import TestCase
+from numpy.testing import assert_array_equal
+from tifffile import tifffile
+
+from roiextractors import MicroManagerTiffImagingExtractor
+from tests.setup_paths import OPHYS_DATA_PATH
+
+
+class TestMicroManagerTiffExtractor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        folder_path = str(
+            OPHYS_DATA_PATH / "imaging_datasets" / "MicroManagerTif" / "TS12_20220407_20hz_noteasy_1"
+        )
+        cls.folder_path = Path(folder_path)
+        file_paths = [
+            "TS12_20220407_20hz_noteasy_1_MMStack_Default.ome.tif",
+            "TS12_20220407_20hz_noteasy_1_MMStack_Default_1.ome.tif",
+            "TS12_20220407_20hz_noteasy_1_MMStack_Default_2.ome.tif",
+        ]
+        cls.file_paths = file_paths
+        extractor = MicroManagerTiffImagingExtractor(folder_path=folder_path)
+        cls.extractor = extractor
+        cls.video = cls._get_test_video()
+
+        # temporary directory for testing assertion when xml file is missing
+        test_dir = tempfile.mkdtemp()
+        cls.test_dir = test_dir
+        shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
+
+    @classmethod
+    def _get_test_video(cls):
+        frames = []
+        for file_path in cls.file_paths:
+            with tifffile.TiffFile(str(cls.folder_path / file_path)) as tif:
+                frames.append(tif.asarray(key=range(5)))
+        return np.concatenate(frames, axis=0)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+        # remove the temporary directory and its contents
+        #shutil.rmtree(cls.test_dir)
+
+    def test_tif_files_are_missing_assertion(self):
+        folder_path = "not a tiff path"
+        exc_msg = f"The TIF image files are missing from '{folder_path}'."
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            MicroManagerTiffImagingExtractor(folder_path=folder_path)
+
+    def test_json_file_is_missing_assertion(self):
+        folder_path = self.test_dir
+        exc_msg = f"The 'DisplaySettings.json' file is not found at '{folder_path}'."
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            MicroManagerTiffImagingExtractor(folder_path=folder_path)
+
+    def test_micromanagertiffextractor_image_size(self):
+        self.assertEqual(self.extractor.get_image_size(), (1024, 1024))
+
+    def test_brukertiffextractor_num_frames(self):
+        self.assertEqual(self.extractor.get_num_frames(), 15)
+
+    def test_brukertiffextractor_sampling_frequency(self):
+        self.assertEqual(self.extractor.get_sampling_frequency(), 20.0)
+
+    def test_brukertiffextractor_channel_names(self):
+        self.assertEqual(self.extractor.get_channel_names(), ["Default"])
+
+    def test_brukertiffextractor_num_channels(self):
+        self.assertEqual(self.extractor.get_num_channels(), 1)
+
+    def test_brukertiffextractor_dtype(self):
+        self.assertEqual(self.extractor.get_dtype(), np.uint16)
+
+    def test_brukertiffextractor_get_video(self):
+        assert_array_equal(self.extractor.get_video(), self.video)
+
+    def test_brukertiffextractor_get_single_frame(self):
+        assert_array_equal(self.extractor.get_frames(frame_idxs=[0]),
+                           self.video[0][np.newaxis, ...])

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -1,6 +1,6 @@
 import shutil
 import tempfile
-from pathlib import Path
+from warnings import warn
 
 import numpy as np
 from hdmf.testing import TestCase
@@ -41,8 +41,11 @@ class TestMicroManagerTiffExtractor(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        Path(cls.folder_path / cls.file_paths[0]).unlink()
-        shutil.rmtree(cls.test_dir)
+        try:
+            Path(cls.folder_path / cls.file_paths[0]).unlink()
+            shutil.rmtree(cls.test_dir)
+        except PermissionError:  # Windows
+            warn(f"Unable to cleanup testing data at {cls.folder_path / cls.file_paths[0]}! Please remove them manually.")
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -28,8 +28,14 @@ class TestMicroManagerTiffExtractor(TestCase):
 
         # temporary directory for testing assertion when xml file is missing
         test_dir = tempfile.mkdtemp()
-        cls.test_dir = test_dir
+        cls.test_dir_1 = test_dir
         shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
+
+        # temporary directory for testing when some of the files are missing
+        test_dir = tempfile.mkdtemp()
+        cls.test_dir_2 = test_dir
+        shutil.copy(Path(folder_path) / file_paths[0], Path(test_dir) / file_paths[0])
+        shutil.copy(Path(folder_path) / "DisplaySettings.json", Path(test_dir) / "DisplaySettings.json")
 
     @classmethod
     def _get_test_video(cls):
@@ -41,7 +47,8 @@ class TestMicroManagerTiffExtractor(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.test_dir)
+        shutil.rmtree(cls.test_dir_1)
+        shutil.rmtree(cls.test_dir_2)
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"
@@ -50,16 +57,14 @@ class TestMicroManagerTiffExtractor(TestCase):
             MicroManagerTiffImagingExtractor(folder_path=folder_path)
 
     def test_json_file_is_missing_assertion(self):
-        folder_path = self.test_dir
-        exc_msg = f"The 'DisplaySettings.json' file is not found at '{folder_path}'."
+        exc_msg = f"The 'DisplaySettings.json' file is not found at '{self.test_dir_1}'."
         with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
-            MicroManagerTiffImagingExtractor(folder_path=folder_path)
+            MicroManagerTiffImagingExtractor(folder_path=self.test_dir_1)
 
     def test_list_of_missing_tif_files_assertion(self):
-        shutil.copy(Path(self.folder_path) / "DisplaySettings.json", Path(self.test_dir) / "DisplaySettings.json")
-        exc_msg = f"Some of the TIF image files at '{self.test_dir}' are missing. The list of files that are missing: {self.file_paths[1:]}"
+        exc_msg = f"Some of the TIF image files at '{self.test_dir_2}' are missing. The list of files that are missing: {self.file_paths[1:]}"
         with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
-            MicroManagerTiffImagingExtractor(folder_path=self.test_dir)
+            MicroManagerTiffImagingExtractor(folder_path=self.test_dir_2)
 
     def test_micromanagertiffextractor_image_size(self):
         self.assertEqual(self.extractor.get_image_size(), (1024, 1024))

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+from pathlib import Path
 from warnings import warn
 
 import numpy as np

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -43,11 +43,11 @@ class TestMicroManagerTiffExtractor(TestCase):
     @classmethod
     def tearDownClass(cls):
         try:
-            Path(cls.folder_path / cls.file_paths[0]).unlink()
+            (Path(cls.test_dir) / cls.file_paths[0]).unlink()
             shutil.rmtree(cls.test_dir)
         except PermissionError:  # Windows
             warn(
-                f"Unable to cleanup testing data at {cls.folder_path / cls.file_paths[0]}! Please remove them manually."
+                f"Unable to cleanup testing data at {cls.test_dir / cls.file_paths[0]}! Please remove them manually."
             )
 
     def test_tif_files_are_missing_assertion(self):

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -41,9 +41,7 @@ class TestMicroManagerTiffExtractor(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        pass
-        # remove the temporary directory and its contents
-        # shutil.rmtree(cls.test_dir)
+        shutil.rmtree(cls.test_dir)
 
     def test_tif_files_are_missing_assertion(self):
         folder_path = "not a tiff path"
@@ -60,23 +58,48 @@ class TestMicroManagerTiffExtractor(TestCase):
     def test_micromanagertiffextractor_image_size(self):
         self.assertEqual(self.extractor.get_image_size(), (1024, 1024))
 
-    def test_brukertiffextractor_num_frames(self):
+    def test_micromanagertiffextractor_num_frames(self):
         self.assertEqual(self.extractor.get_num_frames(), 15)
 
-    def test_brukertiffextractor_sampling_frequency(self):
+    def test_micromanagertiffextractor_sampling_frequency(self):
         self.assertEqual(self.extractor.get_sampling_frequency(), 20.0)
 
-    def test_brukertiffextractor_channel_names(self):
+    def test_micromanagertiffextractor_channel_names(self):
         self.assertEqual(self.extractor.get_channel_names(), ["Default"])
 
-    def test_brukertiffextractor_num_channels(self):
+    def test_micromanagertiffextractor_num_channels(self):
         self.assertEqual(self.extractor.get_num_channels(), 1)
 
-    def test_brukertiffextractor_dtype(self):
+    def test_micromanagertiffextractor_dtype(self):
         self.assertEqual(self.extractor.get_dtype(), np.uint16)
 
-    def test_brukertiffextractor_get_video(self):
+    def test_micromanagertiffextractor_get_video(self):
         assert_array_equal(self.extractor.get_video(), self.video)
 
-    def test_brukertiffextractor_get_single_frame(self):
+    def test_micromanagertiffextractor_get_single_frame(self):
         assert_array_equal(self.extractor.get_frames(frame_idxs=[0]), self.video[0][np.newaxis, ...])
+
+    def test_private_micromanagertiffextractor_num_frames(self):
+        for sub_extractor in self.extractor._imaging_extractors:
+            self.assertEqual(sub_extractor.get_num_frames(), 5)
+
+    def test_private_micromanagertiffextractor_num_channels(self):
+        self.assertEqual(self.extractor._imaging_extractors[0].get_num_channels(), 1)
+
+    def test_private_micromanagertiffextractor_sampling_frequency(self):
+        sub_extractor = self.extractor._imaging_extractors[0]
+        exc_msg = f"The {sub_extractor.extractor_name}Extractor does not support retrieving the imaging rate."
+        with self.assertRaisesWith(NotImplementedError, exc_msg=exc_msg):
+            self.extractor._imaging_extractors[0].get_sampling_frequency()
+
+    def test_private_micromanagertiffextractor_channel_names(self):
+        sub_extractor = self.extractor._imaging_extractors[0]
+        exc_msg = f"The {sub_extractor.extractor_name}Extractor does not support retrieving the name of the channels."
+        with self.assertRaisesWith(NotImplementedError, exc_msg=exc_msg):
+            self.extractor._imaging_extractors[0].get_channel_names()
+
+    def test_private_micromanagertiffextractor_dtype(self):
+        sub_extractor = self.extractor._imaging_extractors[0]
+        exc_msg = f"The {sub_extractor.extractor_name}Extractor does not support retrieving the data type."
+        with self.assertRaisesWith(NotImplementedError, exc_msg=exc_msg):
+            self.extractor._imaging_extractors[0].get_dtype()


### PR DESCRIPTION
Add extractor for the Micro-Manager TIF image format:
- image file stacks are saved into multipage TIF files in OME-TIFF format (.ome.tif files), each of which are up to around 4GB in size.
- The 'DisplaySettings' JSON file contains the properties of Micro-Manager.