### PR TITLE
Rename `MicroManagerTiffImagingExtractor` channel to 'OpticalChannelDefault'

### DIFF
--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -64,7 +64,9 @@ class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
             raise NotImplementedError(
                 f"The {self.extractor_name}Extractor does not currently support multiple color channels."
             )
-        self._channel_names = self.micromanager_metadata["Summary"]["ChNames"]
+        channel_name = self.micromanager_metadata["Summary"]["ChNames"][0]
+        # adding "OpticalChannel" as Micro-Manager uses "Default" as channel name
+        self._channel_names = ["OpticalChannel" + channel_name]
 
         # extact metadata from OME-XML specification
         self._ome_metadata = first_tif.ome_metadata

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -75,7 +75,7 @@ class TestMicroManagerTiffExtractor(TestCase):
         self.assertEqual(self.extractor.get_sampling_frequency(), 20.0)
 
     def test_micromanagertiffextractor_channel_names(self):
-        self.assertEqual(self.extractor.get_channel_names(), ["Default"])
+        self.assertEqual(self.extractor.get_channel_names(), ["OpticalChannelDefault"])
 
     def test_micromanagertiffextractor_num_channels(self):
         self.assertEqual(self.extractor.get_num_channels(), 1)


### PR DESCRIPTION
Micro-Manager uses "Default" as channel name, it is better to rename it to 'OpticalChannelDefault' for clarity