### PR TITLE
Add `MiniscopeImagingExtractor`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: s-weigand/setup-conda@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: s-weigand/setup-conda@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: s-weigand/setup-conda@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Features
 
 * Added support for MicroManager TIFF files with the `MicroManagerTiffImagingExtractor`. [PR #222](https://github.com/catalystneuro/roiextractors/pull/222)
+
 * Added support for Bruker TIFF files with the `BrukerTiffImagingExtractor`. [PR #220](https://github.com/catalystneuro/roiextractors/pull/220)
+
+* Added support for Miniscope AVI files with the `MiniscopeImagingExtractor`. [PR #225](https://github.com/catalystneuro/roiextractors/pull/225)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+### Features
+
+* Added support for Miniscope AVI files with the `MiniscopeImagingExtractor`. [PR #225](https://github.com/catalystneuro/roiextractors/pull/225)
+
+
+
 # v0.5.2
 
 ### Features
@@ -7,8 +13,6 @@
 * Added support for MicroManager TIFF files with the `MicroManagerTiffImagingExtractor`. [PR #222](https://github.com/catalystneuro/roiextractors/pull/222)
 
 * Added support for Bruker TIFF files with the `BrukerTiffImagingExtractor`. [PR #220](https://github.com/catalystneuro/roiextractors/pull/220)
-
-* Added support for Miniscope AVI files with the `MiniscopeImagingExtractor`. [PR #225](https://github.com/catalystneuro/roiextractors/pull/225)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Upcoming
 
+# v0.5.2
+
+### Features
+
+* Added support for MicroManager TIFF files with the `MicroManagerTiffImagingExtractor`. [PR #222](https://github.com/catalystneuro/roiextractors/pull/222)
+* Added support for Bruker TIFF files with the `BrukerTiffImagingExtractor`. [PR #220](https://github.com/catalystneuro/roiextractors/pull/220)
+
+
+
 # v0.5.1
 
 ### Features

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,2 +1,3 @@
 tifffile>=2018.10.18
 scanimage-tiff-reader==1.4.1
+neuroconv[video]

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,4 +1,4 @@
 tifffile>=2018.10.18
 scanimage-tiff-reader==1.4.1
-neuroconv[video]@git+https://github.com/catalystneuro/neuroconv.git@main
+neuroconv[video]>=0.3.0
 natsort>=8.3.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,3 +1,4 @@
 tifffile>=2018.10.18
 scanimage-tiff-reader==1.4.1
 neuroconv[video]
+natsort>=8.3.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,4 +1,4 @@
 tifffile>=2018.10.18
 scanimage-tiff-reader==1.4.1
-neuroconv[video]
+neuroconv[video]@git+https://github.com/catalystneuro/neuroconv.git@main
 natsort>=8.3.1

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ if not gin_config_file_local.exists():
 
 setup(
     name="roiextractors",
-    version="0.5.2",
-    author="Heberto Mayorquin, Cody Baker, Ben Dichter, Alessio Buccino",
+    version="0.5.3",
+    author="Heberto Mayorquin, Szonja Weigl, Cody Baker, Ben Dichter, Alessio Buccino",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",
     url="https://github.com/catalystneuro/roiextractors",

--- a/src/roiextractors/extractorlist.py
+++ b/src/roiextractors/extractorlist.py
@@ -21,6 +21,7 @@ from .extractors.tiffimagingextractors import (
 from .extractors.sbximagingextractor import SbxImagingExtractor
 from .extractors.memmapextractors import NumpyMemmapImagingExtractor
 from .extractors.memmapextractors import MemmapImagingExtractor
+from .extractors.miniscopeimagingextractor import MiniscopeImagingExtractor
 from .multisegmentationextractor import MultiSegmentationExtractor
 from .multiimagingextractor import MultiImagingExtractor
 
@@ -31,6 +32,7 @@ imaging_extractor_full_list = [
     ScanImageTiffImagingExtractor,
     BrukerTiffImagingExtractor,
     MicroManagerTiffImagingExtractor,
+    MiniscopeImagingExtractor,
     NwbImagingExtractor,
     SbxImagingExtractor,
     NumpyMemmapImagingExtractor,

--- a/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
@@ -1,0 +1,1 @@
+from .miniscopeimagingextractor import MiniscopeImagingExtractor

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -105,7 +105,7 @@ class _MiniscopeImagingExtractor(ImagingExtractor):
         end_frame = end_frame or self.get_num_frames()
         start_frame = start_frame or 0
 
-        video = np.empty(shape=(end_frame - start_frame, *self.get_image_size()))
+        video = np.empty(shape=(end_frame - start_frame, *self.get_image_size()), dtype=self.get_dtype())
         with self._video_capture(file_path=str(self.file_path)) as video_obj:
             # Set the starting frame position
             video_obj.current_frame = start_frame

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -1,0 +1,110 @@
+import json
+import re
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+import cv2
+import numpy as np
+from natsort import natsorted
+
+from neuroconv.datainterfaces.behavior.video.video_utils import VideoCaptureContext
+
+from ...imagingextractor import ImagingExtractor
+from ...multiimagingextractor import MultiImagingExtractor
+from ...extraction_tools import PathType, DtypeType
+
+
+class MiniscopeImagingExtractor(MultiImagingExtractor):
+    extractor_name = "MiniscopeImaging"
+    is_writable = True
+    mode = "folder"
+
+    def __init__(self, folder_path: PathType, configuration_file_name: str = "metaData.json"):
+        """
+        The imaging extractor for the Miniscope video (.avi) format.
+        This format consists of video (.avi) file(s) and configuration files (.json).
+
+
+        Parameters
+        ----------
+        folder_path: PathType
+           The folder path that contains the Miniscope data.
+        configuration_file_name: str, optional
+            The name of the JSON configuration file, default is 'metaData.json'.
+        """
+
+        self.folder_path = Path(folder_path)
+
+        miniscope_avi_file_paths = natsorted(list(self.folder_path.glob("*/Miniscope/*.avi")))
+        assert miniscope_avi_file_paths, f"The Miniscope movies (.avi files) are missing from '{self.folder_path}'."
+        miniscope_config_files = natsorted(list(self.folder_path.glob(f"*/Miniscope/{configuration_file_name}")))
+        assert miniscope_config_files, f"The configuration files ({configuration_file_name} files) are missing from '{self.folder_path}'."
+
+        # Set the sampling frequency from the configuration file
+        with open(miniscope_config_files[0], newline="") as f:
+            self._miniscope_config = json.loads(f.read())
+        self._sampling_frequency = float(re.search(r'\d+', self._miniscope_config["frameRate"]).group())
+
+        imaging_extractors = []
+        for file_path in miniscope_avi_file_paths:
+            extractor = _MiniscopeImagingExtractor(file_path=file_path)
+            extractor._sampling_frequency = self._sampling_frequency
+            imaging_extractors.append(extractor)
+
+        super().__init__(imaging_extractors=imaging_extractors)
+
+
+class _MiniscopeImagingExtractor(ImagingExtractor):
+    extractor_name = "_MiniscopeImaging"
+
+    def __init__(self, file_path: PathType):
+        self.file_path = file_path
+        super().__init__()
+
+        with VideoCaptureContext(file_path=str(file_path)) as video_obj:
+            self._num_frames = video_obj.get_video_frame_count()
+            self._image_size = video_obj.get_frame_shape()
+            self._dtype = video_obj.get_video_frame_dtype()
+
+        self._sampling_frequency = None
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_num_channels(self) -> int:
+        return 1
+
+    def get_image_size(self) -> Tuple[int, int]:
+        return self._image_size[:-1]
+
+    def get_sampling_frequency(self):
+        return self._sampling_frequency
+
+    def get_dtype(self) -> DtypeType:
+        return self._dtype
+
+    def get_channel_names(self) -> List[str]:
+        # What are the name of the channels here?
+        # this depends on whether these color channels are duplicated or not
+        # TODO: check in minian how they are reading these files
+        # maybe there is a casting rule from uint8 to 16
+        # they are def. not separate optical channels
+        return ["channel_0"]
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+
+        end_frame = end_frame or self.get_num_frames()
+        start_frame = start_frame or 0
+
+        video = np.empty(shape=(end_frame - start_frame, *self.get_image_size()))
+        with VideoCaptureContext(file_path=str(self.file_path)) as video_obj:
+            # Set the starting frame position
+            video_obj.current_frame = start_frame
+            for frame_number in range(end_frame - start_frame):
+                frame = next(video_obj)
+                # grayscale conversion is based on minian (todo: add ref)
+                video[frame_number] = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
+
+        return video

--- a/tests/test_miniscopeimagingextractor.py
+++ b/tests/test_miniscopeimagingextractor.py
@@ -1,0 +1,103 @@
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+from hdmf.testing import TestCase
+from numpy.testing import assert_array_equal
+
+from roiextractors import MiniscopeImagingExtractor
+
+
+class TestMiniscopeExtractor(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.folder_path = Path("/Volumes/t7-ssd/Miniscope/test_data/C6-J588_Disc5")
+        cls.file_paths = [
+            "15_03_28/Miniscope/0.avi",
+            "15_06_28/Miniscope/0.avi",
+            "15_07_58/Miniscope/0.avi",
+        ]
+        cls.image_size = (480, 752)
+        cls.num_frames = 15
+
+        # temporary directory for testing assertion when json file is missing
+        test_dir = tempfile.mkdtemp()
+        cls.test_dir = Path(test_dir)
+        os.makedirs(cls.test_dir / cls.file_paths[0])
+        shutil.copy(cls.folder_path / cls.file_paths[0], cls.test_dir / cls.file_paths[0])
+
+        cls.extractor = MiniscopeImagingExtractor(folder_path=cls.folder_path)
+
+        cls.video = cls._get_test_video()
+
+    @classmethod
+    def _get_test_video(cls):
+        video = np.empty((cls.num_frames, *cls.image_size))
+
+        for file_num, file_path in enumerate(cls.file_paths):
+            cap = cv2.VideoCapture(str(cls.folder_path / file_path))
+
+            for frame_num in range(5):
+                ret, frame = cap.read()
+                grayscale_frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
+                video[(file_num * 5) + frame_num] = grayscale_frame
+
+            cap.release()
+        return video
+
+    def test_avi_files_are_missing_assertion(self):
+        folder_path = "test"
+        exc_msg = f"The Miniscope movies (.avi files) are missing from '{folder_path}'."
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            MiniscopeImagingExtractor(folder_path=folder_path)
+
+    def test_json_files_are_missing_assertion(self):
+        exc_msg = f"The configuration files (metaData.json files) are missing from '{self.test_dir}'."
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            MiniscopeImagingExtractor(folder_path=self.test_dir)
+
+    def test_miniscopeextractor_num_frames(self):
+        self.assertEqual(self.extractor.get_num_frames(), self.num_frames)
+
+    def test_miniscopeextractor_image_size(self):
+        self.assertEqual(self.extractor.get_image_size(), self.image_size)
+
+    def test_miniscopeextractor_num_channels(self):
+        self.assertEqual(self.extractor.get_num_channels(), 1)
+
+    def test_miniscopeextractor_channel_names(self):
+        self.assertEqual(self.extractor.get_channel_names(), ["channel_0"])
+
+    def test_miniscopeextractor_sampling_frequency(self):
+        self.assertEqual(self.extractor.get_sampling_frequency(), 15.0)
+
+    def test_miniscopeextractor_dtype(self):
+        self.assertEqual(self.extractor.get_dtype(), np.uint8)
+
+    def test_private_miniscopeextractor_num_frames(self):
+        for sub_extractor in self.extractor._imaging_extractors:
+            self.assertEqual(sub_extractor.get_num_frames(), 5)
+
+    def test_private_miniscopeextractor_sampling_frequency(self):
+        sub_extractor = self.extractor._imaging_extractors[0]
+        self.assertEqual(sub_extractor.get_sampling_frequency(), 15.0)
+
+    def test_private_miniscopeextractors_get_video(self):
+        num_frames_per_extractor = 5
+        for num_extractor, sub_extractor in enumerate(self.extractor._imaging_extractors):
+            start = num_extractor * num_frames_per_extractor
+            video_range = np.arange(start, start + num_frames_per_extractor)
+            assert_array_equal(sub_extractor.get_video(), self.video[video_range])
+
+    def test_miniscopeextractor_get_consecutive_frames(self):
+        assert_array_equal(self.extractor.get_video(start_frame=4, end_frame=11), self.video[4:11])
+
+    def test_miniscopeextractor_get_video(self):
+        assert_array_equal(self.extractor.get_video(), self.video)
+
+
+
+

--- a/tests/test_miniscopeimagingextractor.py
+++ b/tests/test_miniscopeimagingextractor.py
@@ -9,12 +9,16 @@ from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal
 
 from roiextractors import MiniscopeImagingExtractor
+from .setup_paths import OPHYS_DATA_PATH
 
 
 class TestMiniscopeExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.folder_path = Path("/Volumes/t7-ssd/Miniscope/test_data/C6-J588_Disc5")
+        # TODO: upload test data (waiting on approval)
+        cls.folder_path = Path(
+            OPHYS_DATA_PATH / "imaging_datasets" / "Miniscope" / "C6-J588_Disc5"
+        )
         cls.file_paths = [
             "15_03_28/Miniscope/0.avi",
             "15_06_28/Miniscope/0.avi",
@@ -69,7 +73,7 @@ class TestMiniscopeExtractor(TestCase):
         self.assertEqual(self.extractor.get_num_channels(), 1)
 
     def test_miniscopeextractor_channel_names(self):
-        self.assertEqual(self.extractor.get_channel_names(), ["channel_0"])
+        self.assertEqual(self.extractor.get_channel_names(), ["OpticalChannel"])
 
     def test_miniscopeextractor_sampling_frequency(self):
         self.assertEqual(self.extractor.get_sampling_frequency(), 15.0)

--- a/tests/test_miniscopeimagingextractor.py
+++ b/tests/test_miniscopeimagingextractor.py
@@ -98,4 +98,7 @@ class TestMiniscopeExtractor(TestCase):
         assert_array_equal(self.extractor.get_video(start_frame=4, end_frame=11), self.video[4:11])
 
     def test_miniscopeextractor_get_video(self):
-        assert_array_equal(self.extractor.get_video(), self.video)
+        video = self.extractor.get_video()
+        assert_array_equal(video, self.video)
+        self.assertEqual(video.shape, (self.num_frames, *self.image_size))
+        self.assertEqual(video.dtype, self.extractor.get_dtype())

--- a/tests/test_miniscopeimagingextractor.py
+++ b/tests/test_miniscopeimagingextractor.py
@@ -15,7 +15,6 @@ from .setup_paths import OPHYS_DATA_PATH
 class TestMiniscopeExtractor(TestCase):
     @classmethod
     def setUpClass(cls):
-        # TODO: upload test data (waiting on approval)
         cls.folder_path = Path(OPHYS_DATA_PATH / "imaging_datasets" / "Miniscope" / "C6-J588_Disc5")
         cls.file_paths = [
             "15_03_28/Miniscope/0.avi",


### PR DESCRIPTION
Add extractor for the Miniscope format:

- `MiniscopeImagingExtractor` takes a `folder_path` that points to the main folder where the microscope and behavior video subfolders are located.

The expected folder structure for Miniscope V3 recordings, based on the example session received from the Tye lab, is organized as follows:

- `C6-J588_Disc5/` (main folder)
  - `15_03_28/` (subfolder corresponding to the recording time)
    - `Miniscope/` (subfolder containing the microscope video stream)
         - `0.avi` (file containing the microscope video)
         - `metaData.json` (file containing the metadata for the microscope device)

