### PR TITLE
added new args to allow for incomplete data import and fixed ypix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To update data later, `cd` into the test directory and run `gin get-content`
 
 ## Class descriptions:
 
-*  **SegmentationExtractor:** An abstract class that contains all the meta-data and output data from the ROI segmentation operation when applied to the pre-processed data. It also contains methods to read from and write to various data formats ouput from  the processing pipelines like SIMA, CaImAn, Suite2p, CNNM-E.
+*  **SegmentationExtractor:** An abstract class that contains all the meta-data and output data from the ROI segmentation operation when applied to the pre-processed data. It also contains methods to read from and write to various data formats ouput from  the processing pipelines like SIMA, CaImAn, Suite2p, CNMF-E.
 
 *  **NumpySegmentationExtractor:** Contains all data coming from a file format for which there is currently no support. To construct this, all data must be entered manually as arguments.
 


### PR DESCRIPTION
This PR contains focuses on some changes to the `Suite2pSegmentationExtractor` class. The following changes are made:
1. Now allows for incomplete data ingestion. New argument (`allow_incomplete_import`). If any files are missing (ie F.npy is not there), it can simply ignore it an move on. Also, a new argument (`warn_missing_files`) toggles printing warnings for missing files.
2. New arguments for searching within a subdirectory specified by the plane number. This is often not how directories are structured and this toggle removes the user burden of restructuring directories if they choose not to.
3. Potential bug fix in the orientation of roi_masks. It seems that the code was writen to flip the roi_masks in the y direction. I'm not sure why this is the case. I removed code that ingested this way and code that undid this during saving.
4. Typo fix in readme.