### PR TITLE
Add note about `get_video` convention to `ImagingExtractor`

### DIFF
--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -112,22 +112,17 @@ class ImagingExtractor(ABC):
 
         Notes:
         ------
-        This is the central extraction function for the ImagingExtractor instances.
-        It should fetch the requested frames from the instance format.
-
         Importantly, we follow the convention that the dimensions of the array are returned in their matrix order,
         More specifically:
+        (time, height, width)
 
-        (frames or time, height or rows, width or columns, depth or volume)
+        Which is equivalent to:
+        (samples, rows, columns)
 
         Note that this does not match the cartesian convention:
-
-        (t, x, y, z)
+        (t, x, y)
 
         Where x is the columns width or and y is the rows or height.
-
-        It is important to check for each format what is the convention used and to transpose the data to the
-        roi convention if needed.
         """
         pass
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -109,6 +109,25 @@ class ImagingExtractor(ABC):
         -------
         video: numpy.ndarray
             The video frames.
+            
+        Notes:
+        ------
+        This is the central extraction function for the ImagingExtractor instances.
+        It should fetch the requested frames from the instance format. 
+        
+        Importantly, we follow the convention that the dimensions of the array are returned in their matrix order,
+        More specifically:
+        
+        (frames or time, height or rows, width or columns, depth or volume)
+        
+        Note that this does not match the cartesian convention:
+        
+        (t, x, y, z)
+        
+        Where x is the columns width or and y is the rows or height.
+        
+        It is important to check for each format what is the convention used and to transpose the data to the
+        roi convention if needed.
         """
         pass
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -109,23 +109,23 @@ class ImagingExtractor(ABC):
         -------
         video: numpy.ndarray
             The video frames.
-            
+
         Notes:
         ------
         This is the central extraction function for the ImagingExtractor instances.
-        It should fetch the requested frames from the instance format. 
-        
+        It should fetch the requested frames from the instance format.
+
         Importantly, we follow the convention that the dimensions of the array are returned in their matrix order,
         More specifically:
-        
+
         (frames or time, height or rows, width or columns, depth or volume)
-        
+
         Note that this does not match the cartesian convention:
-        
+
         (t, x, y, z)
-        
+
         Where x is the columns width or and y is the rows or height.
-        
+
         It is important to check for each format what is the convention used and to transpose the data to the
         roi convention if needed.
         """

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -110,8 +110,8 @@ class ImagingExtractor(ABC):
         video: numpy.ndarray
             The video frames.
 
-        Notes:
-        ------
+        Notes
+        -----
         Importantly, we follow the convention that the dimensions of the array are returned in their matrix order,
         More specifically:
         (time, height, width)


### PR DESCRIPTION
Related to https://github.com/catalystneuro/roiextractors/issues/156

The ideal will be to add this in a section of the read the docs but we are far from it. The standard should be written somewhere and this is a place.