### PR TITLE
Improve Bruker xml parsing by using iterparse instead of parsing the complete xml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming
 
+### Improvements
+* Improved xml parsing with Bruker [PR #267](https://github.com/catalystneuro/roiextractors/pull/267)
+
 
 # v0.5.5
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if not gin_config_file_local.exists():
 
 setup(
     name="roiextractors",
-    version="0.5.5",
+    version="0.5.6",
     author="Heberto Mayorquin, Szonja Weigl, Cody Baker, Ben Dichter, Alessio Buccino",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -65,9 +65,16 @@ def _determine_imaging_is_volumetric(folder_path: PathType) -> bool:
     is_volumetric: bool
         True if the imaging is volumetric (multiplane), False otherwise (single plane).
     """
-    xml_root = _parse_xml(folder_path=folder_path)
-    z_device_element = xml_root.find(".//PVStateValue[@key='zDevice']")
-    is_volumetric = bool(int(z_device_element.attrib["value"]))
+    folder_path = Path(folder_path)
+    xml_file_path = folder_path / f"{folder_path.name}.xml"
+    assert xml_file_path.is_file(), f"The XML configuration file is not found at '{xml_file_path}'."
+
+    is_volumetric = False
+    with open(xml_file_path, "r") as xml_file:
+        for event, elem in ElementTree.iterparse(xml_file, events=("start",)):
+            if elem.tag == "PVStateValue" and elem.attrib.get("key") == "zDevice":
+                is_volumetric = bool(int(elem.attrib["value"]))
+                break  # Stop parsing as we've found the required element
 
     return is_volumetric
 
@@ -107,25 +114,53 @@ class BrukerTiffMultiPlaneImagingExtractor(MultiImagingExtractor):
         """
         natsort = get_package(package_name="natsort", installation_instructions="pip install natsort")
 
-        xml_root = _parse_xml(folder_path=folder_path)
-        channel_names = [file.attrib["channelName"] for file in xml_root.findall(".//File")]
-        unique_channel_names = natsort.natsorted(set(channel_names))
+        folder_path = Path(folder_path)
+        xml_file_path = folder_path / f"{folder_path.name}.xml"
+        assert xml_file_path.is_file(), f"The XML configuration file is not found at '{folder_path}'."
+
+        channel_names = set()
+        channel_ids = set()
+        file_names = []
+
+        # Parse the XML file iteratively to find the first Sequence element
+        first_sequence_element = None
+        with open(xml_file_path, "r") as xml_file:
+            for _, elem in ElementTree.iterparse(xml_file, events=("end",)):
+                if elem.tag == "Sequence":
+                    first_sequence_element = elem
+                    break
+
+            if first_sequence_element is None:
+                raise ValueError("No Sequence element found in the XML configuration file. Can't get streams")
+
+            # Then in the first Sequence we find all the Frame elements
+            if first_sequence_element is not None:
+                # Iterate over all Frame elements within the first Sequence
+                frame_elements = first_sequence_element.findall(".//Frame")
+                for frame_elemenet in frame_elements:
+                    # Iterate over all File elements within each Frame
+                    for file_elem in frame_elemenet.findall("File"):
+                        channel_names.add(file_elem.attrib["channelName"])
+                        channel_ids.add(file_elem.attrib["channel"])
+                        file_names.append(file_elem.attrib["filename"])
+
+        unique_channel_names = natsort.natsorted(channel_names)
+        unique_channel_ids = natsort.natsorted(channel_ids)
+
         streams = dict(channel_streams=unique_channel_names)
         streams["plane_streams"] = dict()
+
         if not _determine_imaging_is_volumetric(folder_path=folder_path):
             return streams
-        # The "channelName" can be any name that the experimenter sets (e.g. 'Ch1', 'Ch2', 'Green', 'Red')
-        # Use the identifier of a channel "channel" (e.g. 1, 2) to match it to the file name
-        channel_ids = [file.attrib["channel"] for file in xml_root.findall(".//File")]
-        unique_channel_ids = natsort.natsorted(set(channel_ids))
+
         for channel_id, channel_name in zip(unique_channel_ids, unique_channel_names):
             plane_naming_pattern = rf"(?P<stream_name>Ch{channel_id}_\d+)"
-            plane_stream_names = [
-                re.search(plane_naming_pattern, file.attrib["filename"])["stream_name"]
-                for file in xml_root.findall(f".//File")
-            ]
+            regular_expression_matches = [re.search(plane_naming_pattern, filename) for filename in file_names]
+            plane_stream_names = [matches["stream_name"] for matches in regular_expression_matches if matches]
+
             unique_plane_stream_names = natsort.natsorted(set(plane_stream_names))
             streams["plane_streams"][channel_name] = unique_plane_stream_names
+
         return streams
 
     def __init__(

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -133,9 +133,9 @@ class TestBrukerTiffExtractorDualPlaneCase(TestCase):
         cls.test_video[..., 1] = second_plane_video
 
     def test_stream_names(self):
-        self.assertEqual(
-            BrukerTiffMultiPlaneImagingExtractor.get_streams(folder_path=self.folder_path), self.available_streams
-        )
+        found_streams = BrukerTiffMultiPlaneImagingExtractor.get_streams(folder_path=self.folder_path)
+        expected_streams =  self.available_streams
+        self.assertEqual(found_streams, expected_streams)        
 
     def test_brukertiffextractor_image_size(self):
         self.assertEqual(self.extractor.get_image_size(), (512, 512, 2))


### PR DESCRIPTION
Currently the Bruker parsing of streams is failng for the files from the Clandinin conversion. The part that fails is the plane extraction as the regular expression does not match properly (the script that generates the failure is on the bottom):

```python
Traceback (most recent call last):
  File "/home/heberto/development/roiextractors/build/dev.py", line 12, in <module>
    streams  = get_streams()
  File "/home/heberto/development/roiextractors/build/dev.py", line 11, in <lambda>
    get_streams = lambda: BrukerTiffMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
  File "/home/heberto/development/roiextractors/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py", line 123, in get_streams
    plane_stream_names = [
  File "/home/heberto/development/roiextractors/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py", line 124, in <listcomp>
    re.search(plane_naming_pattern, file.attrib["filename"])["stream_name"]
TypeError: 'NoneType' object is not subscriptable
```

https://github.com/catalystneuro/roiextractors/blob/b33f00c1adc7f36711616643838c9854c492c9ff/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py#L120-L130

Even worse reading large xml files with the current setup is terribly slow.  Even commenting out the part that fails above this is the current reading speed for a ~ 30 MiB file:

(the script, added at the bottom does this five times)
```python
Execution times: ['9.278', '8.280', '8.254', '8.178', '8.191']
Average time: 8.436
Standard deviation: 0.472
```

This PR fixes the regular expression and uses iterparse to read the file faster. It only reads the information that is needed instead of parsing the whole file to extract the information from the first Sequence. This reduces xml metadata extraction drastically:

```python
Execution times: ['0.011', '0.002', '0.002', '0.002', '0.002']
Average time: 0.004
Standard deviation: 0.004
```

So a thousand-fold improvement with large xml files.

The script:
```python
import timeit
from pathlib import Path
from roiextractors.extractors.tiffimagingextractors.brukertiffimagingextractor import BrukerTiffMultiPlaneImagingExtractor
from statistics import mean, stdev

# Define the folder path
folder_path = Path("/media/heberto/One Touch/Clandinin-CN-data-share/brezovec_example_data/imports/20200228/fly3/func_0/TSeries-02282020-0943-001")
assert folder_path.is_dir()

# Define the function to be timed
get_streams = lambda: BrukerTiffMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
# streams  = get_streams()
# print(f"{streams=}")

# Time the execution
num_executions = 5
times = timeit.repeat(get_streams, number=1, repeat=num_executions)

# Calculate and format the results
average_time = mean(times)
std_dev_time = stdev(times)
formatted_times = [f"{t:.3f}" for t in times]

print("Execution times:", formatted_times)
print("Average time: {:.3f}".format(average_time))
print("Standard deviation: {:.3f}".format(std_dev_time))
```