### PR TITLE
Two small improvements to `BrukerTiffMultiPlaneImagingExtractor`

### DIFF
--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -162,7 +162,7 @@ class BrukerTiffMultiPlaneImagingExtractor(MultiImagingExtractor):
         streams = self.get_streams(folder_path=folder_path)
         plane_streams = streams["plane_streams"]
 
-        assert  len(plane_streams) == 0 (
+        assert len(plane_streams) == 0(
             f"{self.extractor_name}Extractor is for volumetric imaging. "
             "For single imaging plane data use BrukerTiffSinglePlaneImagingExtractor."
         )

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -159,17 +159,20 @@ class BrukerTiffMultiPlaneImagingExtractor(MultiImagingExtractor):
         tif_file_paths = list(folder_path.glob("*.ome.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
 
-        assert _determine_imaging_is_volumetric(folder_path=folder_path), (
+        streams = self.get_streams(folder_path=folder_path)
+        plane_streams = streams["plane_streams"]
+
+        assert  len(plane_streams) == 0 (
             f"{self.extractor_name}Extractor is for volumetric imaging. "
             "For single imaging plane data use BrukerTiffSinglePlaneImagingExtractor."
         )
 
-        streams = self.get_streams(folder_path=folder_path)
         if stream_name is None:
             if len(streams["channel_streams"]) > 1:
                 raise ValueError(
                     "More than one recording stream is detected! Please specify which stream you wish to load with the `stream_name` argument. "
-                    "To see what streams are available, call `BrukerTiffMultiPlaneImagingExtractor.get_stream_names(folder_path=...)`."
+                    "The following channel streams are available:  \n"
+                    f"{streams['channel_streams']}"
                 )
             channel_stream_name = streams["channel_streams"][0]
             stream_name = streams["plane_streams"][channel_stream_name][0]

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -162,7 +162,7 @@ class BrukerTiffMultiPlaneImagingExtractor(MultiImagingExtractor):
         streams = self.get_streams(folder_path=folder_path)
         plane_streams = streams["plane_streams"]
 
-        assert len(plane_streams) == 0(
+        assert len(plane_streams) > 0, (
             f"{self.extractor_name}Extractor is for volumetric imaging. "
             "For single imaging plane data use BrukerTiffSinglePlaneImagingExtractor."
         )


### PR DESCRIPTION
1) Avoid calculating calling `determine_imaging_is_volumetric` which parses the whole xml file twice. The code to get the streams already calculates this and if returns sucesfully the streams have `plane_streams`:

https://github.com/catalystneuro/roiextractors/blob/467bbb00c20d79ecdd383b39aa1ced2734fcb33e/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py#L114-L116

2) When stream_name is not passed and there are multiple channels we can make the life of the user easier by already displaying the options which we have already available.