### PR TITLE
Extract roi indices from redcell.npy in Suite2pExtractor

### DIFF
--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -166,7 +166,13 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
             self._load_npy(file_name="spks.npy", mmap_mode="r", transpose=True) if channel_name == "chan1" else None
         )
 
-        self.iscell = self._load_npy("iscell.npy", mmap_mode="r")
+        # rois segmented from the iamging acquired with second channel (red/anatomical) that match the first channel segmentation
+        redcell=self._load_npy(file_name="redcell.npy", mmap_mode="r")
+        if channel_name=="chan2" and redcell is not None:
+            self.iscell = redcell
+        else:
+            self.iscell = self._load_npy("iscell.npy", mmap_mode="r")
+
 
         # The name of the OpticalChannel object is "OpticalChannel" if there is only one channel, otherwise it is
         # "Chan1" or "Chan2".

--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -167,12 +167,11 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
         )
 
         # rois segmented from the iamging acquired with second channel (red/anatomical) that match the first channel segmentation
-        redcell=self._load_npy(file_name="redcell.npy", mmap_mode="r")
-        if channel_name=="chan2" and redcell is not None:
+        redcell = self._load_npy(file_name="redcell.npy", mmap_mode="r")
+        if channel_name == "chan2" and redcell is not None:
             self.iscell = redcell
         else:
             self.iscell = self._load_npy("iscell.npy", mmap_mode="r")
-
 
         # The name of the OpticalChannel object is "OpticalChannel" if there is only one channel, otherwise it is
         # "Chan1" or "Chan2".


### PR DESCRIPTION
In the case of two-channel acquisition, where one of the channels is a "red" channel holding anatomical information, suite2p outputs also a .npy file named redcell.npy. Similarly to iscell.npy, redcell.npy it's a binary array in which ones represent rois which actually correspond to a cell, identified in the imaging data stream acquired with second channel, and matched the cell identified in the imaging data stream acquired with the first channel. 

I just add few lines of code to extract the accepted/rejected rois ids from redcell.npy instead iscell.npy.