### PR TITLE
Update Version

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -13,6 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update dev version
         run: |
-          sed -i -e "s/version = \"${{ github.event.release.previous_tag_name }}\"/version = \"${{ github.event.release.tag_name }}\"/g" setup.py
+          old_version=${{ github.event.release.tag_name }}
+          old_major_version=${old_version:0:1}
+          old_minor_version=${old_version:2:1}
+          old_patch_version=${old_version:4:1}
+          new_patch_version=`expr $old_patch_version + 1`
+          new_version="$old_major_version.$old_minor_version.$new_patch_version"
+          sed -i -e "s/version = \"$old_version\"/version = \"$new_version\"/g" setup.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,18 @@
+name: Update Dev Version on Release
+
+on:
+    workflow_dispatch:
+    workflow_run:
+        workflows: [auto-publish]
+        types: [completed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update dev version
+        run: |
+          sed -i -e "s/version = \"${{ github.event.release.previous_tag_name }}\"/version = \"${{ github.event.release.tag_name }}\"/g" setup.py
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if not gin_config_file_local.exists():
 
 setup(
     name="roiextractors",
-    version="0.5.6",
+    version="0.5.7",
     author="Heberto Mayorquin, Szonja Weigl, Cody Baker, Ben Dichter, Alessio Buccino",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if not gin_config_file_local.exists():
 setup(
     name="roiextractors",
     version="0.5.7",
-    author="Heberto Mayorquin, Szonja Weigl, Cody Baker, Ben Dichter, Alessio Buccino",
+    author="Heberto Mayorquin, Szonja Weigl, Cody Baker, Ben Dichter, Alessio Buccino, Paul Adkisson",
     author_email="ben.dichter@gmail.com",
     description="Python module for extracting optical physiology ROIs and traces for various file types and formats",
     url="https://github.com/catalystneuro/roiextractors",


### PR DESCRIPTION
This PR manually updates the version of ROI extractors to accommodate latest release.

It also sets up a github workflow to automatically increment the patch version number upon every subsequent release. But, the workflow needs to be in the default branch before it can be deployed and tested. So, the workflow file will likely need a  follow up PR for debugging.