### PR TITLE
Add _roi_response_denoised to store denoised traces 

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -11,14 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout New Branch
+        run: |
+          git checkout -b update_dev_version
       - name: Update dev version
         run: |
-          old_version=${{ github.event.release.tag_name }}
+          git fetch --prune --unshallow --tags
+          tags="$(git tag --list)"
+          latest_tag=${tags: -6 : 6}
+          old_version=${latest_tag:1:5}
+          echo "Old Version: $old_version"
           old_major_version=${old_version:0:1}
           old_minor_version=${old_version:2:1}
           old_patch_version=${old_version:4:1}
           new_patch_version=`expr $old_patch_version + 1`
           new_version="$old_major_version.$old_minor_version.$new_patch_version"
-          sed -i -e "s/version = \"$old_version\"/version = \"$new_version\"/g" setup.py
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+          echo "New Version: $new_version"
+          sed -i -e "s/version=\"$old_version\"/version=\"$new_version\"/g" setup.py
+          echo "old_version=$old_version" >> "$GITHUB_ENV"
+          echo "new_version=$new_version" >> "$GITHUB_ENV"
+      - name: Commit Changes and Create Pull Request
+        run: |
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config --global user.name github-actions[bot]
+          git commit . -m "Update dev version from $old_version to $new_version"
+          git push origin update_dev_version
+          gh pr create --title "[Github.CI] Update dev version from $old_version to $new_version" --body "version: $old_version --> $new_version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Improvements
 * Improved xml parsing with Bruker [PR #267](https://github.com/catalystneuro/roiextractors/pull/267)
 
+### Features
+* Add support to get background components: add `get_background_ids()`, `get_background_image_masks()`, `get_background_pixel_masks()` to `SegmentationExtractor`. [PR #291](https://github.com/catalystneuro/roiextractors/pull/291)
+
+* Add distinction for raw roi response and denoised roi response in `CaimanSegmentationExtractor`: [PR #291](https://github.com/catalystneuro/roiextractors/pull/291)
+
+* Bug fix for the `CaimanSegmentationExtractor`: correctly extract temporal and spatial background components [PR #291](https://github.com/catalystneuro/roiextractors/pull/291)
 
 # v0.5.5
 

--- a/docs/source/build_re.rst
+++ b/docs/source/build_re.rst
@@ -25,6 +25,7 @@ To build a custom SegmentationExtractor that interfaces with the output of a cus
             self._roi_response_raw = self._load_traces()# define a method to extract Flourescence traces
             self._roi_response_dff = self._load_traces()# define a method to extract dF/F traces if any else None
             self._roi_response_neuropil = self._load_traces()# define a method to extract neuropil info if any else None
+            self._roi_response_denoised = self._load_traces() # define a method to extract denoised traces if any else None
             self._roi_response_deconvolved = self._load_traces() # define a method to extract deconvolved traces if any else None
             self._image_correlation = self._load_summary_images()# define method to extract a correlation image else None
             self._image_mean = self._load_summary_images() # define method to extract a mean image else None

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -56,7 +56,8 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         self.file_path = file_path
         self._dataset_file = self._file_extractor_read()
         self._roi_response_dff = self._trace_extractor_read("F_dff")
-        self._roi_response_neuropil = self._trace_extractor_read("C")
+        self._roi_response_denoised = self._trace_extractor_read("C")
+        self._roi_response_neuropil = self._trace_extractor_read("b")
         self._roi_response_deconvolved = self._trace_extractor_read("S")
         self._image_correlation = self._summary_image_read()
         self._sampling_frequency = self._dataset_file["params"]["data"]["fr"][()]
@@ -177,8 +178,10 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
             estimates = f.create_group("estimates")
             params = f.create_group("params")
             # adding to estimates:
+            if segmentation_object.get_traces(name="denoised") is not None:
+                estimates.create_dataset("C", data=segmentation_object.get_traces(name="denoised"))
             if segmentation_object.get_traces(name="neuropil") is not None:
-                estimates.create_dataset("C", data=segmentation_object.get_traces(name="neuropil"))
+                estimates.create_dataset("b", data=segmentation_object.get_traces(name="neuropil"))
             if segmentation_object.get_traces(name="dff") is not None:
                 estimates.create_dataset("F_dff", data=segmentation_object.get_traces(name="dff"))
             if segmentation_object.get_traces(name="deconvolved") is not None:

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -128,7 +128,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
 
         if field in self._dataset_file["estimates"]:
             return lazy_ops.DatasetView(self._dataset_file["estimates"][field]).lazy_transpose()
-        
+
     def _raw_trace_extractor_read(self):
         roi_response_raw = self._dataset_file["estimates"]["C"][:] + self._dataset_file["estimates"]["YrA"][:]
         return np.array(roi_response_raw.T)

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -55,6 +55,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         SegmentationExtractor.__init__(self)
         self.file_path = file_path
         self._dataset_file = self._file_extractor_read()
+        self._roi_response_raw = self._trace_extractor_read("C") + self._trace_extractor_read("Yr")
         self._roi_response_dff = self._trace_extractor_read("F_dff")
         self._roi_response_denoised = self._trace_extractor_read("C")
         self._roi_response_neuropil = self._trace_extractor_read("f")

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -130,6 +130,13 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
             return lazy_ops.DatasetView(self._dataset_file["estimates"][field]).lazy_transpose()
 
     def _raw_trace_extractor_read(self):
+        """Read the denoised trace and the residual trace from the h5py file and sum them to obtain the raw roi response trace.
+
+        Returns
+        -------
+        roi_response_raw: numpy.ndarray
+            The raw roi response trace.
+        """
         roi_response_raw = self._dataset_file["estimates"]["C"][:] + self._dataset_file["estimates"]["YrA"][:]
         return np.array(roi_response_raw.T)
 

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -63,6 +63,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         self._image_correlation = self._summary_image_read()
         self._sampling_frequency = self._dataset_file["params"]["data"]["fr"][()]
         self._image_masks = self._image_mask_sparse_read()
+        self._background_image_masks = self._background_image_mask_read()
 
     def __del__(self):  # TODO: refactor segmentation extractors who use __del__ together into a base class
         """Close the h5py file when the object is deleted."""
@@ -95,6 +96,19 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         ).toarray()
         image_masks = np.reshape(image_mask_in, (*self.get_image_size(), -1), order="F")
         return image_masks
+
+    def _background_image_mask_read(self):
+        """Read the image masks from the h5py file.
+
+        Returns
+        -------
+        image_masks: numpy.ndarray
+            The image masks for each background components.
+        """
+
+        background_image_mask_in = self._dataset_file["estimates"]["b"]
+        background_image_masks = np.reshape(background_image_mask_in, (*self.get_image_size(), -1), order="F")
+        return background_image_masks
 
     def _trace_extractor_read(self, field):
         """Read the traces specified by the field from the estimates dataset of the h5py file.

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -55,7 +55,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         SegmentationExtractor.__init__(self)
         self.file_path = file_path
         self._dataset_file = self._file_extractor_read()
-        self._roi_response_raw = self._trace_extractor_read("C") + self._trace_extractor_read("Yr")
+        self._roi_response_raw = self._raw_trace_extractor_read()
         self._roi_response_dff = self._trace_extractor_read("F_dff")
         self._roi_response_denoised = self._trace_extractor_read("C")
         self._roi_response_neuropil = self._trace_extractor_read("f")
@@ -128,6 +128,10 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         if field in self._dataset_file["estimates"]:
             return lazy_ops.DatasetView(self._dataset_file["estimates"][field]).lazy_transpose()
 
+    def _raw_trace_extractor_read(self):
+        roi_response_raw = self._dataset_file["estimates"]["C"][:] + self._dataset_file["estimates"]["YrA"][:]
+        return roi_response_raw.T
+    
     def _summary_image_read(self):
         """Read the summary image (Cn) from the estimates dataset of the h5py file."""
         if self._dataset_file["estimates"].get("Cn"):

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -57,7 +57,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         self._dataset_file = self._file_extractor_read()
         self._roi_response_dff = self._trace_extractor_read("F_dff")
         self._roi_response_denoised = self._trace_extractor_read("C")
-        self._roi_response_neuropil = self._trace_extractor_read("b")
+        self._roi_response_neuropil = self._trace_extractor_read("f")
         self._roi_response_deconvolved = self._trace_extractor_read("S")
         self._image_correlation = self._summary_image_read()
         self._sampling_frequency = self._dataset_file["params"]["data"]["fr"][()]
@@ -181,7 +181,7 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
             if segmentation_object.get_traces(name="denoised") is not None:
                 estimates.create_dataset("C", data=segmentation_object.get_traces(name="denoised"))
             if segmentation_object.get_traces(name="neuropil") is not None:
-                estimates.create_dataset("b", data=segmentation_object.get_traces(name="neuropil"))
+                estimates.create_dataset("f", data=segmentation_object.get_traces(name="neuropil"))
             if segmentation_object.get_traces(name="dff") is not None:
                 estimates.create_dataset("F_dff", data=segmentation_object.get_traces(name="dff"))
             if segmentation_object.get_traces(name="deconvolved") is not None:

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -5,7 +5,7 @@ Classes
 SegmentationExtractor
     Abstract class that contains all the meta-data and output data from the ROI segmentation operation when applied to
     the pre-processed data. It also contains methods to read from and write to various data formats output from the
-    processing pipelines like SIMA, CaImAn, Suite2p, CNNM-E.
+    processing pipelines like SIMA, CaImAn, Suite2p, CNMF-E.
 FrameSliceSegmentationExtractor
     Class to get a lazy frame slice.
 """
@@ -26,7 +26,7 @@ class SegmentationExtractor(ABC):
     An abstract class that contains all the meta-data and output data from
     the ROI segmentation operation when applied to the pre-processed data.
     It also contains methods to read from and write to various data formats
-    output from the processing pipelines like SIMA, CaImAn, Suite2p, CNNM-E.
+    output from the processing pipelines like SIMA, CaImAn, Suite2p, CNMF-E.
     All the methods with @abstract decorator have to be defined by the
     format specific classes that inherit from this.
     """

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -346,7 +346,7 @@ class SegmentationExtractor(ABC):
         """
         if self._roi_response_neuropil is not None and len(self._roi_response_neuropil.shape) > 0:
             return self._roi_response_neuropil.shape[1]
-        
+
     def get_channel_names(self) -> List[str]:
         """Get names of channels in the pipeline.
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -40,6 +40,7 @@ class SegmentationExtractor(ABC):
         self._roi_response_raw = None
         self._roi_response_dff = None
         self._roi_response_neuropil = None
+        self._roi_response_denoised = None
         self._roi_response_deconvolved = None
         self._image_correlation = None
         self._image_mean = None
@@ -223,13 +224,14 @@ class SegmentationExtractor(ABC):
         -------
         _roi_response_dict: dict
             dictionary with key, values representing different types of RoiResponseSeries:
-                Fluorescence, Neuropil, Deconvolved, Background, etc.
+                Raw Fluorescence, DeltaFOverF, Denoised, Neuropil, Deconvolved, Background, etc.
         """
         return dict(
             raw=self._roi_response_raw,
             dff=self._roi_response_dff,
             neuropil=self._roi_response_neuropil,
             deconvolved=self._roi_response_deconvolved,
+            denoised=self._roi_response_denoised,
         )
 
     def get_images_dict(self):

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -356,7 +356,7 @@ def check_segmentation_return_types(seg: SegmentationExtractor):
     )
     assert isinstance(seg.get_traces_dict(), dict)
     assert isinstance(seg.get_images_dict(), dict)
-    assert {"raw", "dff", "neuropil", "deconvolved"} == set(seg.get_traces_dict().keys())
+    assert {"raw", "dff", "neuropil", "deconvolved", "deconvolved"} == set(seg.get_traces_dict().keys())
 
 
 def check_imaging_equal(

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -356,7 +356,7 @@ def check_segmentation_return_types(seg: SegmentationExtractor):
     )
     assert isinstance(seg.get_traces_dict(), dict)
     assert isinstance(seg.get_images_dict(), dict)
-    assert {"raw", "dff", "neuropil", "deconvolved", "deconvolved"} == set(seg.get_traces_dict().keys())
+    assert {"raw", "dff", "neuropil", "deconvolved", "denoised"} == set(seg.get_traces_dict().keys())
 
 
 def check_imaging_equal(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -168,7 +168,7 @@ class TestExtractors(TestCase):
 
             num_frames = extractor.get_num_frames()
             num_rois = extractor.get_num_rois()
-            num_background_compontents = extractor.get_num_background_compontents()
+            num_background_components = extractor.get_num_background_components()
             for trace_name, trace in extractor.get_traces_dict().items():
                 if trace is None:
                     continue
@@ -176,8 +176,8 @@ class TestExtractors(TestCase):
                 assert extractor.get_traces(name=trace_name).shape[0] == num_frames
 
                 if trace_name == "neuropil":
-                    assert trace.shape[1] == num_background_compontents
-                    assert extractor.get_traces(name=trace_name).shape[1] == num_background_compontents
+                    assert trace.shape[1] == num_background_components
+                    assert extractor.get_traces(name=trace_name).shape[1] == num_background_components
                 else:
                     assert trace.shape[1] == num_rois
                     assert extractor.get_traces(name=trace_name).shape[1] == num_rois

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -168,14 +168,19 @@ class TestExtractors(TestCase):
 
             num_frames = extractor.get_num_frames()
             num_rois = extractor.get_num_rois()
+            num_background_compontents = extractor.get_num_background_compontents()
             for trace_name, trace in extractor.get_traces_dict().items():
                 if trace is None:
                     continue
                 assert trace.shape[0] == num_frames
-                assert trace.shape[1] == num_rois
-
                 assert extractor.get_traces(name=trace_name).shape[0] == num_frames
-                assert extractor.get_traces(name=trace_name).shape[1] == num_rois
+
+                if trace_name == "neuropil":
+                    assert trace.shape[1] == num_background_compontents
+                    assert extractor.get_traces(name=trace_name).shape[1] == num_background_compontents
+                else:
+                    assert trace.shape[1] == num_rois
+                    assert extractor.get_traces(name=trace_name).shape[1] == num_rois
 
         except NotImplementedError:
             return


### PR DESCRIPTION
Denoised calcium traces should be distinguished from raw calcium traces.
See discussion in https://github.com/catalystneuro/roiextractors/issues/287#issuecomment-1956837952

This implementation should also fix #249.

TODO
- [x] Add background spatial components
- [x] Add raw traces as C+Yr
- [x] Add testing