### PR TITLE
Fix Update Dev Version on Release Workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,6 +4,7 @@
 name: Upload Package to PyPI
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,7 +4,6 @@
 name: Upload Package to PyPI
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,7 +3,7 @@ name: Update Dev Version on Release
 on:
     workflow_dispatch:
     workflow_run:
-        workflows: [auto-publish]
+        workflows: [Upload Package to PyPI]
         types: [completed]
 
 jobs:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,4 +38,4 @@ jobs:
           git push origin update_dev_version
           gh pr create --title "[Github.CI] Update dev version from $old_version to $new_version" --body "version: $old_version --> $new_version"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAULS_PAT }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,4 +38,4 @@ jobs:
           git push origin update_dev_version
           gh pr create --title "[Github.CI] Update dev version from $old_version to $new_version" --body "version: $old_version --> $new_version"
         env:
-          GITHUB_TOKEN: ${{ secrets.PAULS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* The triggering workflow name for update version was incorrectly set to `auto-publish` (the name of the yaml file).  It has been renamed to `Upload Package to PyPI` (the name field of the workflow): [PR #304](https://github.com/catalystneuro/roiextractors/pull/304).
+
 # v0.5.7
 
 ### Features


### PR DESCRIPTION
The triggering workflow name for update version was incorrectly set to `auto-publish` (the name of the yaml file).  It should have been `Upload Package to PyPI` (the name field of the workflow).

No easy way to retrigger the upload package to pypi workflow -- in fact using `skip-existing` is specifically recommended against by action authors: https://github.com/pypa/gh-action-pypi-publish.  So, we'll just have to check if this works properly on the next release.

Also, the triggered PR doesn't run the appropriate tests bc of a github actions bug with the `secrets.GITHUB_TOKEN` (see [stack overflow](https://stackoverflow.com/questions/52200096/github-pull-request-waiting-for-status-to-be-reported)) --> so that is fixed by using my PAT -- see #308