### PR TITLE
Fix Cron Bug with Assess-file-changes

### DIFF
--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -36,7 +36,7 @@ jobs:
           echo "CHANGELOG_UPDATED=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo $file
-            if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == "setup.py" || $file == ".github/"* ]]
+            if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == "setup.py" || $file == ".github/"* && $file != ".github/workflows/assess-file-changes.yml" ]]
             then
               echo "Source changed"
               echo "SOURCE_CHANGED=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -36,7 +36,7 @@ jobs:
           echo "CHANGELOG_UPDATED=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo $file
-            if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == "setup.py" || $file == ".github/"* && $file != ".github/workflows/assess-file-changes.yml" ]]
+            if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == ".github/"* && $file != ".github/workflows/assess-file-changes.yml" ]]
             then
               echo "Source changed"
               echo "SOURCE_CHANGED=true" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * The triggering workflow name for update version was incorrectly set to `auto-publish` (the name of the yaml file).  It has been renamed to `Upload Package to PyPI` (the name field of the workflow): [PR #304](https://github.com/catalystneuro/roiextractors/pull/304).
 
+* Fixed bug with automatic changelog test that was causing it to fail for daily tests: [PR #310](https://github.com/catalystneuro/roiextractors/pull/310)
+
 # v0.5.7
 
 ### Features


### PR DESCRIPTION
Based on the failed daily actions, it looks like the assess-file-changes.yml shows up as changed --> excluding it from the checked files should prevent daily test failures.

Also excluded setup.py so that Update dev version workflow doesn't fail (see #311)