### PR TITLE
fix inscopix dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 ### Fixes
 
 * Remove unecessary scipy import error handling: [#315](https://github.com/catalystneuro/roiextractors/pull/315)
+* Fixed the typing returned by the `InscopixImagingExtractor.get_dtype` method: [#326](https://github.com/catalystneuro/roiextractors/pull/326)
 
 ### Improvements
-- The `Suite2PSegmentationExtractor` now produces an error when a required sub-file is missin: [#330](https://github.com/catalystneuro/roiextractors/pull/330)
+
+* The `Suite2PSegmentationExtractor` now produces an error when a required sub-file is missin: [#330](https://github.com/catalystneuro/roiextractors/pull/330)
 
 ### Testing
 

--- a/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
+++ b/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
@@ -53,5 +53,5 @@ class InscopixImagingExtractor(ImagingExtractor):
         end_frame = end_frame or self.get_num_frames()
         return np.array([self.movie.get_frame_data(i) for i in range(start_frame, end_frame)])
 
-    def get_dtype(self):
+    def get_dtype(self) -> np.dtype:
         return np.dtype(self.movie.data_type)

--- a/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
+++ b/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
@@ -54,4 +54,4 @@ class InscopixImagingExtractor(ImagingExtractor):
         return np.array([self.movie.get_frame_data(i) for i in range(start_frame, end_frame)])
 
     def get_dtype(self):
-        return self.movie.data_type
+        return np.dtype(self.movie.data_type)

--- a/tests/test_inscopiximagingextractor.py
+++ b/tests/test_inscopiximagingextractor.py
@@ -19,6 +19,7 @@ def test_inscopiximagingextractor_movie_128x128x100_part1():
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (100, 128, 128)
     assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_dtype().itemsize
 
 
 def test_inscopiximagingextractor_movie_longer_than_3_min():
@@ -33,6 +34,7 @@ def test_inscopiximagingextractor_movie_longer_than_3_min():
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (1248, 33, 29)
     assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_dtype().itemsize
 
 
 def test_inscopiximagingextractor_movie_u8():
@@ -47,3 +49,4 @@ def test_inscopiximagingextractor_movie_u8():
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (5, 3, 4)
     assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_dtype().itemsize

--- a/tests/test_inscopiximagingextractor.py
+++ b/tests/test_inscopiximagingextractor.py
@@ -13,12 +13,12 @@ def test_inscopiximagingextractor_movie_128x128x100_part1():
 
     assert extractor.get_num_frames() == 100
     assert extractor.get_image_size() == (128, 128)
-    assert extractor.get_dtype() == dtype("float32")
+    assert extractor.get_dtype() is dtype("float32")
     assert extractor.get_sampling_frequency() == 10.0
     assert extractor.get_channel_names() == ["channel_0"]
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (100, 128, 128)
-    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype is extractor.get_dtype()
     assert extractor.get_dtype().itemsize
 
 
@@ -28,12 +28,12 @@ def test_inscopiximagingextractor_movie_longer_than_3_min():
 
     assert extractor.get_num_frames() == 1248
     assert extractor.get_image_size() == (33, 29)
-    assert extractor.get_dtype() == dtype("uint16")
+    assert extractor.get_dtype() is dtype("uint16")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 5.5563890139076415)
     assert extractor.get_channel_names() == ["channel_0"]
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (1248, 33, 29)
-    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype is extractor.get_dtype()
     assert extractor.get_dtype().itemsize
 
 
@@ -43,10 +43,10 @@ def test_inscopiximagingextractor_movie_u8():
 
     assert extractor.get_num_frames() == 5
     assert extractor.get_image_size() == (3, 4)
-    assert extractor.get_dtype() == dtype("uint8")
+    assert extractor.get_dtype() is dtype("uint8")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 20.0)
     assert extractor.get_channel_names() == ["channel_0"]
     assert extractor.get_num_channels() == 1
     assert extractor.get_video().shape == (5, 3, 4)
-    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype == extractor.get_dtype()
+    assert extractor.get_frames(frame_idxs=[0], channel=0).dtype is extractor.get_dtype()
     assert extractor.get_dtype().itemsize


### PR DESCRIPTION
Apparently `np.uint16` is different from `np.dtype(np.uint16)`