### PR TITLE
BaseSegmentation class improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,27 @@
 
 ### Back-compatibility break
 
-* Remove support for Python 3.8 [PR #325](https://github.com/catalystneuro/roiextractors/pull/325)
+* Remove support for Python 3.8: [PR #325](https://github.com/catalystneuro/roiextractors/pull/325)
 
 ### Features
 
-* Add InscopixImagingExtractor [#276](https://github.com/catalystneuro/roiextractors/pull/276)
+* Add InscopixImagingExtractor: [#276](https://github.com/catalystneuro/roiextractors/pull/276)
 * Updated testing workflows to include python 3.12, m1/intel macos, and dev tests to check neuroconv: [PR #317](https://github.com/catalystneuro/roiextractors/pull/317)
 
 ### Fixes
 
-* Remove unecessary scipy import error handling [#315](https://github.com/catalystneuro/roiextractors/pull/315)
+* Remove unnecessary `scipy` import error handling: [#315](https://github.com/catalystneuro/roiextractors/pull/315)
+
+### Improvements
+
+* Added `_image_mask` initialization in `BaseSegmentationExtractor`; combined `abstractmethod`s into top of file: [#327](https://github.com/catalystneuro/roiextractors/pull/327)
 
 ### Testing
 
 * Updated testing workflows to include python 3.12, m1/intel macos, and dev tests to check neuroconv: [PR #317](https://github.com/catalystneuro/roiextractors/pull/317)
 * Added daily testing workflow and fixed bug with python 3.12 by upgrading scanimage-tiff-reader version: [PR #321](https://github.com/catalystneuro/roiextractors/pull/321)
+
+
 
 # v0.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Upcoming (v0.6.0)
+# Upcoming (v0.5.9)
 
-### Back-compatibility break
+### Depreciations
 
 * Remove support for Python 3.8: [PR #325](https://github.com/catalystneuro/roiextractors/pull/325)
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -78,7 +78,7 @@ class SegmentationExtractor(ABC):
             2-D array: image height x image width
         """
         pass
-    
+
     def get_num_frames(self) -> int:
         """Get the number of frames in the recording (duration of recording).
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -32,7 +32,7 @@ class SegmentationExtractor(ABC):
     """
 
     def __init__(self):
-        """Create a new SegmentationExtractor from specified data type (unique to each child SegmentationExtractor)."""
+        """Create a new SegmentationExtractor for a specific data format (unique to each child SegmentationExtractor)."""
         self._sampling_frequency = None
         self._times = None
         self._channel_names = ["OpticalChannel"]
@@ -44,6 +44,7 @@ class SegmentationExtractor(ABC):
         self._roi_response_deconvolved = None
         self._image_correlation = None
         self._image_mean = None
+        self._image_mask = None
 
     @abstractmethod
     def get_accepted_list(self) -> list:
@@ -67,6 +68,17 @@ class SegmentationExtractor(ABC):
         """
         pass
 
+    @abstractmethod
+    def get_image_size(self) -> ArrayType:
+        """Get frame size of movie (height, width).
+
+        Returns
+        -------
+        no_rois: array_like
+            2-D array: image height x image width
+        """
+        pass
+    
     def get_num_frames(self) -> int:
         """Get the number of frames in the recording (duration of recording).
 
@@ -203,17 +215,6 @@ class SegmentationExtractor(ABC):
             background_ids = range(self.get_num_background_components())
 
         return _pixel_mask_extractor(self.get_background_image_masks(background_ids=background_ids), background_ids)
-
-    @abstractmethod
-    def get_image_size(self) -> ArrayType:
-        """Get frame size of movie (height, width).
-
-        Returns
-        -------
-        no_rois: array_like
-            2-D array: image height x image width
-        """
-        pass
 
     def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         """Return a new SegmentationExtractor ranging from the start_frame to the end_frame.


### PR DESCRIPTION
Writing a custom segmentation extractor, noticed a couple of things

i) `self._image_mask` is used in later methods but never specific in the base `__init__`; not a huge deal, but figured I'd include it there to at least demonstrate how to include it during file read

ii) moved an `abstractmethod` towards the top of the class to make it easier to spot (since it needs to be defined in any child)