### PR TITLE
add scan_line_rate, grid_spacing and origin_coords from scanimage metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Add InscopixImagingExtractor [#276](https://github.com/catalystneuro/roiextractors/pull/276)
 * Updated testing workflows to include python 3.12, m1/intel macos, and dev tests to check neuroconv: [PR #317](https://github.com/catalystneuro/roiextractors/pull/317)
+* Updated  `parse_metadata()` from `scaimagetiff_utils` to include `scan_line_rate`, `grid_spacing`, `grid_spacing_unit`,`origin_coords`, `origin_coords_unit`
 
 ### Fixes
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -133,8 +133,7 @@ def parse_metadata(metadata: dict) -> dict:
     grid_spacing_unit = "n.a"
     origin_coords = None
     origin_coords_unit = "n.a"
-    try:
-        # Attempt to access the nested dictionary keys
+    if roi_metadata["imagingRoiGroup"]["rois"].__contains__("scanfields"):
         scanfields = roi_metadata["imagingRoiGroup"]["rois"]["scanfields"]
         fov_size_in_um = np.array(scanfields["sizeXY"])
         frame_dimension = np.array(scanfields["pixelResolutionXY"])
@@ -142,9 +141,6 @@ def parse_metadata(metadata: dict) -> dict:
         grid_spacing_unit = "micrometers"
         origin_coords = scanfields["centerXY"]
         origin_coords_unit = "micrometers"
-
-    except (KeyError, Exception):
-        pass
 
     metadata_parsed = dict(
         sampling_frequency=sampling_frequency,

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -95,6 +95,12 @@ def parse_metadata(metadata: dict) -> dict:
     - frames_per_slice
     - channel_names
     - num_channels
+    - scan_line_rate,
+    - grid_spacing,
+    - grid_spacing_unit,
+    - origin_coords,
+    - origin_coords_unit,
+    - roi_metadata,
 
     Parameters
     ----------

--- a/tests/test_scanimage_utils.py
+++ b/tests/test_scanimage_utils.py
@@ -70,6 +70,11 @@ def test_parse_matlab_vector_invalid():
                 "num_planes": 20,
                 "frames_per_slice": 24,
                 "channel_names": ["Channel 1"],
+                "scan_line_rate": 15847.40847329236,
+                "grid_spacing": [0.01757812, 0.01757812],
+                "grid_spacing_unit": "micrometers",
+                "origin_coords": [0, 0],
+                "origin_coords_unit": "micrometers",
                 "roi_metadata": {
                     "imagingRoiGroup": {
                         "ver": 1,
@@ -147,6 +152,11 @@ def test_parse_matlab_vector_invalid():
                 "num_planes": 2,
                 "frames_per_slice": 2,
                 "channel_names": ["Channel 1", "Channel 4"],
+                "scan_line_rate": 15843.868185354244,
+                "grid_spacing": None,
+                "grid_spacing_unit": "n.a",
+                "origin_coords": None,
+                "origin_coords_unit": "n.a",
                 "roi_metadata": {
                     "imagingRoiGroup": {
                         "ver": 1,


### PR DESCRIPTION
Add `scan_line_rate`, `grid_spacing` and `origin_coords` from scanimage metadata "RoiGroups"