### PR TITLE
Fix Update Testing Data Workflow

### DIFF
--- a/.github/workflows/deploy_pr_tests.yaml
+++ b/.github/workflows/deploy_pr_tests.yaml
@@ -1,0 +1,21 @@
+name: Deploy PR Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    update-testing-data:
+        uses: ./.github/workflows/update-testing-data.yml
+
+    run-tests:
+        needs: update-testing-data
+        uses: ./.github/workflows/run-tests.yml
+
+    dev-tests:
+        needs: update-testing-data
+        uses: ./.github/workflows/dev-testing.yaml

--- a/.github/workflows/dev-testing.yaml
+++ b/.github/workflows/dev-testing.yaml
@@ -1,11 +1,7 @@
 name: Dev Testing
 on:
-  pull_request:
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  workflow_call:
 
 jobs:
   run:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           path: ./ophys_testing_data
           key: ophys-datasets-042023-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-          
+
       - if: steps.cache-ophys-datasets.outputs.cache-hit == false
         name: Install and configure AWS CLI
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,12 +1,7 @@
 name: Full Tests
 on:
-  pull_request:
   workflow_dispatch:
   workflow_call:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   run:
@@ -51,16 +46,6 @@ jobs:
         with:
           path: ./ophys_testing_data
           key: ophys-datasets-042023-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-
-      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
-        name: Install and configure AWS CLI
-        run: |
-          pip install awscli
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
-        name: Download data from S3
-        run: aws s3 cp --recursive s3://${{ secrets.S3_GIN_BUCKET }}//ophys_testing_data ./ophys_testing_data
 
       - name: Run full pytest with coverage
         run: pytest -n auto --dist loadscope --cov=./ --cov-report xml:./codecov.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           path: ./ophys_testing_data
           key: ophys-datasets-042023-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+          
+      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
+        name: Install and configure AWS CLI
+        run: |
+          pip install awscli
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
+        name: Download data from S3
+        run: aws s3 cp --recursive s3://${{ secrets.S3_GIN_BUCKET }}//ophys_testing_data ./ophys_testing_data
 
       - name: Run full pytest with coverage
         run: pytest -n auto --dist loadscope --cov=./ --cov-report xml:./codecov.xml

--- a/.github/workflows/update-testing-data.yml
+++ b/.github/workflows/update-testing-data.yml
@@ -38,7 +38,7 @@ jobs:
       - if: steps.cache-ophys-datasets.outputs.cache-hit == false
         name: Install and configure AWS CLI
         run: |
-          pip install awscli==1.29.56
+          pip install awscli
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove unnecessary `scipy` import error handling: [#315](https://github.com/catalystneuro/roiextractors/pull/315)
 * Fixed the typing returned by the `InscopixImagingExtractor.get_dtype` method: [#326](https://github.com/catalystneuro/roiextractors/pull/326)
 * Detect Changelog Updates was moved to its own dedicated workflow to avoid daily testing failures: [#336](https://github.com/catalystneuro/roiextractors/pull/336)
+* Fixed the Update Testing Data Workflow by unpinning the version of awscli: [#339](https://github.com/catalystneuro/roiextractors/pull/339)
 
 ### Improvements
 


### PR DESCRIPTION
This PR fixes the Update Testing Data Workflow by unpinning the version of awscli.

See [this failing daily](https://github.com/catalystneuro/roiextractors/actions/runs/9351682817) for context.