### PR TITLE
Change criteria for volumetric in Bruker tiff extractor

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: pytest tests/test_internals -n auto --dist loadscope
 
       - name: Test full installation (-e needed for codecov report)
-        run: pip install -e .[full]
+        run: pip install .[full]
 
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: pytest tests/test_internals -n auto --dist loadscope
 
       - name: Test full installation (-e needed for codecov report)
-        run: pip install .[full]
+        run: pip install -e .[full]
 
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fixed the typing returned by the `InscopixImagingExtractor.get_dtype` method: [#326](https://github.com/catalystneuro/roiextractors/pull/326)
 * Detect Changelog Updates was moved to its own dedicated workflow to avoid daily testing failures: [#336](https://github.com/catalystneuro/roiextractors/pull/336)
 * Fixed the Daily testing workflows by passing along the appropriate secrets: [#340](https://github.com/catalystneuro/roiextractors/pull/340)
+* Change the criteria of determining if Bruker data is volumetric [#342](https://github.com/catalystneuro/roiextractors/pull/342)
 
 ### Improvements
 

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -54,7 +54,7 @@ def _determine_frame_rate(element: ElementTree.Element, file_names: Optional[Lis
 
 
 def _determine_imaging_is_volumetric(folder_path: PathType) -> bool:
-    """Determine whether imaging is volumetric based on 'zDevice' configuration value.
+    """Determine whether imaging is volumetric.
 
     Parameters
     ----------
@@ -70,11 +70,22 @@ def _determine_imaging_is_volumetric(folder_path: PathType) -> bool:
     xml_file_path = folder_path / f"{folder_path.name}.xml"
     assert xml_file_path.is_file(), f"The XML configuration file is not found at '{xml_file_path}'."
 
+    is_series_type_volumetric = {
+        "TSeries ZSeries Element": True,  # XYZT
+        "TSeries Timed Element": False,  # XYT
+        "ZSeries": True,  # ZT (not a time series)
+        "Single": False,  # Single image (not a time series)
+    }
+
     is_volumetric = False
     for event, elem in ElementTree.iterparse(xml_file_path, events=("start",)):
-        if elem.tag == "PVStateValue" and elem.attrib.get("key") == "zDevice":
-            is_volumetric = bool(int(elem.attrib["value"]))
-            break  # Stop parsing as we've found the required element
+        if elem.tag == "Sequence":
+            series_type = elem.attrib.get("type")
+            if series_type in is_series_type_volumetric:
+                is_volumetric = is_series_type_volumetric[series_type]
+                break
+            else:
+                raise ValueError(f"Unknown series type: {series_type}, please raise an issue in roiextractor repository")
 
     return is_volumetric
 

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -85,7 +85,9 @@ def _determine_imaging_is_volumetric(folder_path: PathType) -> bool:
                 is_volumetric = is_series_type_volumetric[series_type]
                 break
             else:
-                raise ValueError(f"Unknown series type: {series_type}, please raise an issue in roiextractor repository")
+                raise ValueError(
+                    f"Unknown series type: {series_type}, please raise an issue in roiextractor repository"
+                )
 
     return is_volumetric
 


### PR DESCRIPTION
This should fix #341

As described in #341 the current criteria that we use to determine if an image is volumetric is wrong. 
[mhturner](https://github.com/mhturner) proposed what I think is a very simple solution which I have implemented here. This fetches the sequence type and uses a simple dictionary to determine the nature of the data.

I tested this on volumetric data that I got from the Clandinin lab and this seems to be working.