### PR TITLE
Remove wheel requirement and remove testing dependencies from the CI.

### DIFF
--- a/.github/workflows/dev-testing.yaml
+++ b/.github/workflows/dev-testing.yaml
@@ -22,15 +22,12 @@ jobs:
       - name: Global Setup
         run: |
             pip install -U pip
-            pip install pytest-xdist
             git config --global user.email "CI@example.com"
             git config --global user.name "CI Almighty"
-            pip install wheel==0.41.2  # needed for scanimage
 
       - name: Install full requirements
         run: |
-            pip install .[test]
-            pip install .[full]
+            pip install .[test,full]
 
       - name: Clone and Install NeuroConv
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,8 @@ jobs:
       - name: Global Setup
         run: |
           pip install -U pip
-          pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip install wheel==0.41.2  # needed for scanimage
 
       - name: Install roiextractors with minimal requirements
         run: pip install .[test]
@@ -37,8 +35,8 @@ jobs:
       - name: Run minimal tests
         run: pytest tests/test_internals -n auto --dist loadscope
 
-      - name: Test full installation (-e needed for codecov report)
-        run: pip install -e .[full]
+      - name: Test full installation
+        run: pip install .[full]
 
       - name: Get ophys_testing_data current head hash
         id: ophys
@@ -60,4 +58,5 @@ jobs:
           file: ./codecov.xml
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
+          codecov_yml_path: ./codecov.yml
+          verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 * Updated testing workflows to include python 3.12, m1/intel macos, and dev tests to check neuroconv: [PR #317](https://github.com/catalystneuro/roiextractors/pull/317)
 * Added daily testing workflow and fixed bug with python 3.12 by upgrading scanimage-tiff-reader version: [PR #321](https://github.com/catalystneuro/roiextractors/pull/321)
+* Remove wheel from requirements and move CI dependencies to test requirements [PR #348](https://github.com/catalystneuro/roiextractors/pull/348)
 
 
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,5 +1,5 @@
 tifffile>=2018.10.18
-scanimage-tiff-reader==1.4.1.4
+scanimage-tiff-reader>=1.4.1.4
 neuroconv[video]>=0.4.6  # Uses the VideoCaptureContext class
 natsort>=8.3.1
 isx>=1.0.4

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 parameterized==0.8.1
 spikeextractors>=0.9.10
+pytest-xdist


### PR DESCRIPTION
Three things in the PR:

* The latest version of scan image supports modern python build systems so installing wheel is no longer necessary:
https://gitlab.com/vidriotech/scanimagetiffreader-python/-/merge_requests/2/diffs
* Moving the dependencies to testing instead of having the implicit in the CI. Companion to https://github.com/catalystneuro/neuroconv/pull/913
* Remove the editable installation because that mode is unstable in setuptools https://setuptools.pypa.io/en/latest/userguide/development_mode.html