### PR TITLE
Bye bye spikeextractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 * Updated testing workflows to include python 3.12, m1/intel macos, and dev tests to check neuroconv: [PR #317](https://github.com/catalystneuro/roiextractors/pull/317)
 * Added daily testing workflow and fixed bug with python 3.12 by upgrading scanimage-tiff-reader version: [PR #321](https://github.com/catalystneuro/roiextractors/pull/321)
-
+* Use Spikeinterface instead of Spikeextractors for toy_example [PR #349](https://github.com/catalystneuro/roiextractors/pull/349)
 
 
 # v0.5.8

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
 parameterized==0.8.1
-spikeextractors>=0.9.10
+spikeinterface>=0.100.7

--- a/src/roiextractors/example_datasets/toy_example.py
+++ b/src/roiextractors/example_datasets/toy_example.py
@@ -157,11 +157,9 @@ def toy_example(
         mode=mode,
     )
 
-    from spikeinterface.core import generate_ground_truth_recording
+    from spikeinterface.core import generate_sorting
 
-    rec, sort = generate_ground_truth_recording(
-        num_channels=1, durations=[duration], num_units=num_rois, sampling_frequency=sampling_frequency
-    )
+    sort = generate_sorting(durations=[duration], num_units=num_rois, sampling_frequency=sampling_frequency)
 
     # create decaying response
     resp_samples = int(decay_time * sampling_frequency)
@@ -169,17 +167,16 @@ def toy_example(
     tresp = np.arange(resp_samples)
     resp = np.exp(-tresp / resp_tau)
 
-    num_frames = rec.get_num_frames()  # TODO This should be changed to sampling_frequency x duration
-    num_of_units = sort.get_unit_ids()  # TODO This to be changed by num_rois
+    num_frames = sampling_frequency * duration
 
     # convolve response with ROIs
-    raw = np.zeros(num_of_units, num_frames)  # TODO Change to new standard formating with time in first axis
-    deconvolved = np.zeros(num_of_units, num_frames)  # TODO Change to new standard formating with time in first axis
+    raw = np.zeros(num_rois, num_frames)  # TODO Change to new standard formating with time in first axis
+    deconvolved = np.zeros(num_rois, num_frames)  # TODO Change to new standard formating with time in first axis
     neuropil = noise_std * np.random.randn(
-        num_of_units, num_frames
+        num_rois, num_frames
     )  # TODO Change to new standard formating with time in first axis
     frames = num_frames
-    for u_i, unit in range(num_of_units):
+    for u_i, unit in range(num_rois):
         unit = u_i + 1  # spikeextractor toy example has unit ids starting at 1
         for s in sort.get_unit_spike_train(unit):  # TODO build a local function that generates frames with spikes
             if s < num_frames:

--- a/src/roiextractors/example_datasets/toy_example.py
+++ b/src/roiextractors/example_datasets/toy_example.py
@@ -157,14 +157,10 @@ def toy_example(
         mode=mode,
     )
 
-    # generate spike trains
-    import spikeextractors as se
+    from spikeinterface.core import generate_ground_truth_recording
 
-    rec, sort = se.example_datasets.toy_example(
-        duration=duration,
-        K=num_rois,
-        num_channels=1,
-        sampling_frequency=sampling_frequency,
+    rec, sort = generate_ground_truth_recording(
+        num_channels=1, durations=[duration], num_units=num_rois, sampling_frequency=sampling_frequency
     )
 
     # create decaying response


### PR DESCRIPTION
Been meaning to this for a while @CodyCBakerPhD  : )

We can still avoid this dependency if we just define an in-house function that gets spike trains which should not be tood hard. But I really don't have time right now. So I am doing this just because at some point spikeextractors will stop working so I am doing it now before I forget.