### PR TITLE
Protect import in sima

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * The `Suite2PSegmentationExtractor` now produces an error when a required sub-file is missin: [#330](https://github.com/catalystneuro/roiextractors/pull/330)
 * Added `_image_mask` initialization in `BaseSegmentationExtractor`; combined `abstractmethod`s into top of file: [#327](https://github.com/catalystneuro/roiextractors/pull/327)
 * Optimize parsing of xml with `lxml` library for Burker extractors: [#346](https://github.com/catalystneuro/roiextractors/pull/346)
+* Protect sima and dill expoert [#346](https://github.com/catalystneuro/roiextractors/pull/346)
 
 ### Testing
 

--- a/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -16,14 +16,6 @@ import numpy as np
 from ...extraction_tools import PathType
 from ...segmentationextractor import SegmentationExtractor
 
-try:
-    import sima
-    import dill
-
-    HAVE_SIMA = True
-except ImportError:
-    HAVE_SIMA = False
-
 
 class SimaSegmentationExtractor(SegmentationExtractor):
     """A segmentation extractor for Sima.
@@ -34,7 +26,6 @@ class SimaSegmentationExtractor(SegmentationExtractor):
     """
 
     extractor_name = "SimaSegmentation"
-    installed = HAVE_SIMA  # check at class level if installed or not
     is_writable = False
     mode = "file"
     # error message when not installed
@@ -51,6 +42,15 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         sima_segmentation_label: str
             name of the ROIs in the dataset from which to extract all ROI info
         """
+
+        try:
+            import sima
+            import dill
+
+            HAVE_SIMA = True
+        except ImportError:
+            HAVE_SIMA = False
+
         assert HAVE_SIMA, self.installation_mesg
         SegmentationExtractor.__init__(self)
         self.file_path = file_path
@@ -79,6 +79,8 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         old_pkl_loc: str
             Path of the pickle file to be converted
         """
+        import dill
+
         # Make a name for the new pickle
         old_pkl_loc = old_pkl_loc + "/"
         for dirpath, dirnames, filenames in os.walk(old_pkl_loc):
@@ -108,6 +110,8 @@ class SimaSegmentationExtractor(SegmentationExtractor):
 
     def _file_extractor_read(self):
         """Read the sima file and return the sima.ImagingDataset object."""
+        import sima
+
         _img_dataset = sima.ImagingDataset.load(self.file_path)
         _img_dataset._savedir = self.file_path
         return _img_dataset

--- a/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -42,7 +42,6 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         sima_segmentation_label: str
             name of the ROIs in the dataset from which to extract all ROI info
         """
-
         try:
             import sima
             import dill


### PR DESCRIPTION
Delaying imports to intialization time is good for perofrmance reasons.

It would also stop from appearing on my stack when I am looking for any exceptions : P

Could we have this please?