### PR TITLE
Improve error message for tiff imaging extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * The `Suite2PSegmentationExtractor` now produces an error when a required sub-file is missin: [#330](https://github.com/catalystneuro/roiextractors/pull/330)
 * Added `_image_mask` initialization in `BaseSegmentationExtractor`; combined `abstractmethod`s into top of file: [#327](https://github.com/catalystneuro/roiextractors/pull/327)
 * Optimize parsing of xml with `lxml` library for Burker extractors: [#346](https://github.com/catalystneuro/roiextractors/pull/346)
+* Improve error message when `TiffImagingExtractor` is not able to form memmap [#353](https://github.com/catalystneuro/roiextractors/pull/353)
 
 ### Testing
 

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -56,14 +56,23 @@ class TiffImagingExtractor(ImagingExtractor):
 
         try:
             self._video = tifffile.memmap(self.file_path, mode="r")
-        except ValueError as e:
-            warn(
-                f"memmap of TIFF file could not be established due to the following error: {e}. "
-                "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access.",
-                stacklevel=2,
-            )
-            with tifffile.TiffFile(self.file_path) as tif:
-                self._video = tif.asarray()
+        except Exception as e:
+
+            try:
+                with tifffile.TiffFile(self.file_path) as tif:
+                    self._video = tif.asarray()
+                warn(
+                    f"memmap of TIFF file could not be established due to the following error: {e}. "
+                    "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access.",
+                    stacklevel=2,
+                )
+            except Exception as e2:
+                raise RuntimeError(
+                    f"Memory mapping failed: {e}. \n"
+                    f"Attempt to read the TIFF file directly also failed: {e2}. \n"
+                    f"Consider using ScanImageTiffExtractor for lazy data access, check the file integrity. \n"
+                    f"If problems persist, please report an issue at roiextractors/issues."
+                )
 
         shape = self._video.shape
         if len(shape) == 3:

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -56,10 +56,11 @@ class TiffImagingExtractor(ImagingExtractor):
 
         try:
             self._video = tifffile.memmap(self.file_path, mode="r")
-        except ValueError:
+        except ValueError as e:
             warn(
-                "memmap of TIFF file could not be established. Reading entire matrix into memory. "
-                "Consider using the ScanImageTiffExtractor for lazy data access."
+                f"memmap of TIFF file could not be established due to the following error: {e}. "
+                "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access.",
+                stacklevel=2,
             )
             with tifffile.TiffFile(self.file_path) as tif:
                 self._video = tif.asarray()

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -63,7 +63,7 @@ class TiffImagingExtractor(ImagingExtractor):
                     self._video = tif.asarray()
                 warn(
                     f"memmap of TIFF file could not be established due to the following error: {e}. "
-                    "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access.",
+                    "Reading entire matrix into memory. Consider using the ScanImageTiffSinglePlaneImagingExtractor or ScanImageTiffMultiPlaneImagingExtractor for lazy data access.",
                     stacklevel=2,
                 )
             except Exception as e2:

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -70,7 +70,7 @@ class TiffImagingExtractor(ImagingExtractor):
                 raise RuntimeError(
                     f"Memory mapping failed: {e}. \n"
                     f"Attempt to read the TIFF file directly also failed: {e2}. \n"
-                    f"Consider using ScanImageTiffExtractor for lazy data access, check the file integrity. \n"
+                    f"Consider using ScanImageTiffSinglePlaneImagingExtractor or ScanImageTiffMultiPlaneImagingExtractor for lazy data access, check the file integrity. \n"
                     f"If problems persist, please report an issue at roiextractors/issues."
                 )
 

--- a/tests/test_scan_image_tiff.py
+++ b/tests/test_scan_image_tiff.py
@@ -38,7 +38,7 @@ class TestScanImageTiffExtractor(TestCase):
             warn_type=UserWarning,
             exc_msg=(
                 "memmap of TIFF file could not be established due to the following error: image data are not memory-mappable. "
-                "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access."
+                "Reading entire matrix into memory. Consider using the ScanImageTiffSinglePlaneImagingExtractor or ScanImageTiffMultiPlaneImagingExtractor for lazy data access."
             ),
         ):
             TiffImagingExtractor(file_path=self.file_path, sampling_frequency=30.0)

--- a/tests/test_scan_image_tiff.py
+++ b/tests/test_scan_image_tiff.py
@@ -37,8 +37,8 @@ class TestScanImageTiffExtractor(TestCase):
         with self.assertWarnsWith(
             warn_type=UserWarning,
             exc_msg=(
-                "memmap of TIFF file could not be established. Reading entire matrix into memory. "
-                "Consider using the ScanImageTiffExtractor for lazy data access."
+                "memmap of TIFF file could not be established due to the following error: image data are not memory-mappable. "
+                "Reading entire matrix into memory. Consider using the ScanImageTiffExtractor for lazy data access."
             ),
         ):
             TiffImagingExtractor(file_path=self.file_path, sampling_frequency=30.0)


### PR DESCRIPTION
Related to:
https://github.com/catalystneuro/neuroconv/issues/995


The reason why the file could not be memmap should be propagated. This improves the current error handling and displays a more informative error to the final user.