### PR TITLE
Added specific error message for single-frame scanimage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# Upcoming (v0.5.9)
+# Upcoming (v0.5.10)
+
+### Features
+
+### Fixes
+* Added specific error message for single-frame scanimage data [PR #360](https://github.com/catalystneuro/roiextractors/pull/360)
+
+### Improvements
+
+### Testing
+
+# v0.5.9
 
 ### Deprecations
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -299,7 +299,12 @@ class ScanImageTiffSinglePlaneImagingExtractor(ImagingExtractor):
         ScanImageTiffReader = _get_scanimage_reader()
         with ScanImageTiffReader(str(self.file_path)) as io:
             shape = io.shape()  # [frames, rows, columns]
-        if len(shape) == 3:
+        if len(shape) == 2:  # [rows, columns]
+            raise NotImplementedError(
+                "Extractor cannot handle single-frame ScanImageTiff data. Please raise an issue to request this feature: "
+                "https://github.com/catalystneuro/roiextractors/issues "
+            )
+        elif len(shape) == 3:
             self._total_num_frames, self._num_rows, self._num_columns = shape
             if (
                 self._num_planes == 1


### PR DESCRIPTION
Fixes #298

Upon reflection, it seems unnecessary to add a whole new imaging extractor to support an edge case that I doubt will actually surface in real ScanImageTiff datasets (single frame files). If we ever run into an actual use case, I will revisit this issue.