### PR TITLE
Refactor Miniscope Extractor Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Improvements
 * Removed unnecessary import checks for scipy, h5py, and zarr [PR #364](https://github.com/catalystneuro/roiextractors/pull/364)
 * Improved the error message for the `set_timestamps` method in the `ImagingExtractor` class[PR #377](https://github.com/catalystneuro/roiextractors/pull/377)
+* Renamed `MiniscopeImagingExtractor` to`MiniscopeMultiRecordingImagingExtractor` class[PR #374](https://github.com/catalystneuro/roiextractors/pull/374)
 
 ### Testing
 

--- a/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
@@ -11,4 +11,4 @@ MiniscopeImagingExtractor
     An ImagingExtractor for the Miniscope video (.avi) format.
 """
 
-from .miniscopeimagingextractor import MiniscopeImagingExtractor
+from .miniscopeimagingextractor import MiniscopeImagingExtractor, MiniscopeMultiSegmentExtractor

--- a/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/__init__.py
@@ -11,4 +11,4 @@ MiniscopeImagingExtractor
     An ImagingExtractor for the Miniscope video (.avi) format.
 """
 
-from .miniscopeimagingextractor import MiniscopeImagingExtractor, MiniscopeMultiSegmentExtractor
+from .miniscopeimagingextractor import MiniscopeImagingExtractor, MiniscopeMultiRecordingImagingExtractor

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -18,14 +18,14 @@ from ...multiimagingextractor import MultiImagingExtractor
 from ...extraction_tools import PathType, DtypeType, get_package
 
 
-class MiniscopeImagingExtractor(MultiImagingExtractor):  # TODO: rename to MiniscopeMultiImagingExtractor
+class MiniscopeMultiSegmentExtractor(MultiImagingExtractor):
     """An ImagingExtractor for the Miniscope video (.avi) format.
 
     This format consists of video (.avi) file(s) and configuration files (.json).
-    One _MiniscopeImagingExtractor is created for each video file and then combined into the MiniscopeImagingExtractor.
+    One _MiniscopeSingleVideoExtractor is created for each video file and then combined into the MiniscopeImagingExtractor.
     """
 
-    extractor_name = "MiniscopeImaging"
+    extractor_name = "MiniscopeMultiImaging"
     is_writable = True
     mode = "folder"
 
@@ -58,24 +58,28 @@ class MiniscopeImagingExtractor(MultiImagingExtractor):  # TODO: rename to Minis
 
         imaging_extractors = []
         for file_path in miniscope_avi_file_paths:
-            extractor = _MiniscopeImagingExtractor(file_path=file_path)
+            extractor = _MiniscopeSingleVideoExtractor(file_path=file_path)
             extractor._sampling_frequency = self._sampling_frequency
             imaging_extractors.append(extractor)
 
         super().__init__(imaging_extractors=imaging_extractors)
 
 
-class _MiniscopeImagingExtractor(ImagingExtractor):
-    """An ImagingExtractor for the Miniscope video (.avi) format.
+# Temporal renaming to keep backwards compatibility
+MiniscopeImagingExtractor = MiniscopeMultiSegmentExtractor
 
-    This format consists of a single video (.avi) file and configuration file (.json).
-    Multiple _MiniscopeImagingExtractor are combined into the MiniscopeImagingExtractor for public access.
+
+class _MiniscopeSingleVideoExtractor(ImagingExtractor):
+    """An auxiliar extractor to get data from a single Miniscope video (.avi) file.
+
+    This format consists of a single video (.avi)
+    Multiple _MiniscopeSingleVideoExtractor are combined into the MiniscopeImagingExtractor for public access.
     """
 
-    extractor_name = "_MiniscopeImaging"
+    extractor_name = "_MiniscopeSingleVideo"
 
     def __init__(self, file_path: PathType):
-        """Create a _MiniscopeImagingExtractor instance from a file path.
+        """Create a _MiniscopeSingleVideoExtractor instance from a file path.
 
         Parameters
         ----------

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -10,6 +10,7 @@ import json
 import re
 from pathlib import Path
 from typing import Optional, Tuple, List
+import warnings
 
 import numpy as np
 
@@ -49,7 +50,7 @@ class MiniscopeMultiRecordingImagingExtractor(MultiImagingExtractor):
     as a unified, continuous dataset.
     """
 
-    extractor_name = "MiniscopeMultiImaging"
+    extractor_name = "MiniscopeMultiRecordingImagingExtractor"
     is_writable = True
     mode = "folder"
 
@@ -90,7 +91,15 @@ class MiniscopeMultiRecordingImagingExtractor(MultiImagingExtractor):
 
 
 # Temporary renaming to keep backwards compatibility
-MiniscopeImagingExtractor = MiniscopeMultiRecordingImagingExtractor
+class MiniscopeImagingExtractor(MiniscopeMultiRecordingImagingExtractor):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "MiniscopeImagingExtractor is unstable and might change its signature. "
+            "Please use MiniscopeMultiRecordingImagingExtractor instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class _MiniscopeSingleVideoExtractor(ImagingExtractor):

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -18,11 +18,35 @@ from ...multiimagingextractor import MultiImagingExtractor
 from ...extraction_tools import PathType, DtypeType, get_package
 
 
-class MiniscopeMultiSegmentExtractor(MultiImagingExtractor):
-    """An ImagingExtractor for the Miniscope video (.avi) format.
+class MiniscopeMultiRecordingImagingExtractor(MultiImagingExtractor):
+    """
+    ImagingExtractor processes multiple separate Miniscope recordings within the same session.
 
-    This format consists of video (.avi) file(s) and configuration files (.json).
-    One _MiniscopeSingleVideoExtractor is created for each video file and then combined into the MiniscopeImagingExtractor.
+    Important, this extractor consolidates the recordings as a single continuous dataset.
+
+    Expected directory structure:
+
+    .
+    ├── C6-J588_Disc5
+    │   ├── 15_03_28  (timestamp)
+    │   │   ├── BehavCam_2
+    │   │   ├── metaData.json
+    │   │   └── Miniscope
+    │   ├── 15_06_28 (timestamp)
+    │   │   ├── BehavCam_2
+    │   │   ├── metaData.json
+    │   │   └── Miniscope
+    │   └── 15_07_58 (timestamp)
+    │       ├── BehavCam_2
+    │       ├── metaData.json
+    │       └── Miniscope
+    └──
+
+    Where the Miniscope folders contain a collection of .avi files and a metaData.json file.
+
+    For each video file, a _MiniscopeSingleVideoExtractor is created. These individual extractors
+    are then combined into the MiniscopeMultiRecordingImagingExtractor to handle the session's recordings
+    as a unified, continuous dataset.
     """
 
     extractor_name = "MiniscopeMultiImaging"
@@ -30,7 +54,7 @@ class MiniscopeMultiSegmentExtractor(MultiImagingExtractor):
     mode = "folder"
 
     def __init__(self, folder_path: PathType):
-        """Create a MiniscopeImagingExtractor instance from a folder path.
+        """Create a MiniscopeMultiRecordingImagingExtractor instance from a folder path.
 
         Parameters
         ----------
@@ -65,15 +89,15 @@ class MiniscopeMultiSegmentExtractor(MultiImagingExtractor):
         super().__init__(imaging_extractors=imaging_extractors)
 
 
-# Temporal renaming to keep backwards compatibility
-MiniscopeImagingExtractor = MiniscopeMultiSegmentExtractor
+# Temporary renaming to keep backwards compatibility
+MiniscopeImagingExtractor = MiniscopeMultiRecordingImagingExtractor
 
 
 class _MiniscopeSingleVideoExtractor(ImagingExtractor):
     """An auxiliar extractor to get data from a single Miniscope video (.avi) file.
 
     This format consists of a single video (.avi)
-    Multiple _MiniscopeSingleVideoExtractor are combined into the MiniscopeImagingExtractor for public access.
+    Multiple _MiniscopeSingleVideoExtractor are combined by downstream extractors to extract the data
     """
 
     extractor_name = "_MiniscopeSingleVideo"


### PR DESCRIPTION
First PR in the direction of #356

It does two things:
* It renames the class `MiniscopeImagingExtractor` to `MiniscopeMultiSegmentExtractor` which I think better encompasses its scope and purpose. It then does a renaming to keep (for the moment) backward compatibility. 
* It renames `_MiniscopeImagingExtractor` to `_MiniscopeSingleVideoExtractor` for similar reasons.

These two changes pave the road to implement a future `MiniscopeImagingExtractor` in the lines of the comments in f #356