### PR TITLE
pin zarr<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
   "psutil>=5.8.0",
   "PyYAML",
   "lxml",
-  "packaging"
+  "packaging",
+  "zarr>=2,<3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
[Zarr 3](https://zarr.dev/blog/zarr-python-3-release/) was causing daily tests to fail: https://github.com/catalystneuro/roiextractors/actions/runs/12711056881