### PR TITLE
Deprecate channel argument in `get_frames`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Fixes
 
-## Improvements
+### Deprecations
+* The 'channel' parameter in get_frames() and get_video() methods is deprecated and will be removed in August 2025.
+
+### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)
 
 

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -112,6 +112,26 @@ class Hdf5ImagingExtractor(ImagingExtractor):
         self._file.close()
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0):
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         squeeze_data = False
         if isinstance(frame_idxs, int):
             squeeze_data = True
@@ -124,6 +144,28 @@ class Hdf5ImagingExtractor(ImagingExtractor):
         return frames
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._video.lazy_slice[start_frame:end_frame, :, :, channel].dsetread()
 
     def get_image_size(self) -> Tuple[int, int]:

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -7,6 +7,7 @@ MemmapImagingExtractor
 """
 
 from pathlib import Path
+from warnings import warn
 
 import numpy as np
 import psutil
@@ -38,6 +39,27 @@ class MemmapImagingExtractor(ImagingExtractor):
         super().__init__()
 
     def get_frames(self, frame_idxs=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like, optional
+            Indices of frames to return. If None, returns all frames.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if frame_idxs is None:
             frame_idxs = [frame for frame in range(self.get_num_frames())]
 
@@ -50,6 +72,28 @@ class MemmapImagingExtractor(ImagingExtractor):
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: Optional[int] = 0
     ) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         frame_idxs = range(start_frame, end_frame)
         return self.get_frames(frame_idxs=frame_idxs, channel=channel)
 

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -10,6 +10,7 @@ NumpySegmentationExtractor
 
 from pathlib import Path
 from typing import Optional, Tuple
+from warnings import warn
 
 import numpy as np
 
@@ -113,6 +114,26 @@ class NumpyImagingExtractor(ImagingExtractor):
         return num_frames, num_rows, num_columns, num_channels
 
     def get_frames(self, frame_idxs=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like, optional
+            Indices of frames to return. If None, returns all frames.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if frame_idxs is None:
             frame_idxs = [frame for frame in range(self.get_num_frames())]
 
@@ -123,6 +144,28 @@ class NumpyImagingExtractor(ImagingExtractor):
         return frames
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._video[start_frame:end_frame, ..., channel]
 
     def get_image_size(self) -> Tuple[int, int]:

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -167,6 +167,28 @@ class NwbImagingExtractor(ImagingExtractor):
         )
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0):
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            from warnings import warn
+
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         squeeze_data = False
         if isinstance(frame_idxs, int):
             squeeze_data = True
@@ -179,6 +201,30 @@ class NwbImagingExtractor(ImagingExtractor):
         return frames
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            from warnings import warn
+
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         start_frame = start_frame if start_frame is not None else 0
         end_frame = end_frame if end_frame is not None else self.get_num_frames()
 

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -165,11 +165,56 @@ class SbxImagingExtractor(ImagingExtractor):
         return np_data
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.array:
-        frame_out = np.iinfo("uint16").max - self._data.transpose(4, 2, 1, 0, 3)[frame_idxs, :, :, channel, 0]
+        """Get specific video frames from indices.
 
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            from warnings import warn
+
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        frame_out = np.iinfo("uint16").max - self._data.transpose(4, 2, 1, 0, 3)[frame_idxs, :, :, channel, 0]
         return frame_out
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            from warnings import warn
+
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         frame_out = np.iinfo("uint16").max - self._data[channel, :, :, 0, start_frame:end_frame]
         return frame_out.transpose(2, 1, 0)
 

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -568,6 +568,30 @@ class _BrukerTiffSinglePlaneImagingExtractor(ImagingExtractor):
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
     ) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            from warnings import warn
+
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         with self.tifffile.TiffFile(self.file_path, _multifile=False) as tif:
             pages = tif.pages
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -562,8 +562,28 @@ class ScanImageTiffImagingExtractor(ImagingExtractor):  # TODO: Remove this extr
             )
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> np.ndarray:
-        ScanImageTiffReader = _get_scanimage_reader()
+        """Get specific video frames from indices.
 
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        ScanImageTiffReader = _get_scanimage_reader()
         squeeze_data = False
         if isinstance(frame_idxs, int):
             squeeze_data = True
@@ -599,8 +619,30 @@ class ScanImageTiffImagingExtractor(ImagingExtractor):  # TODO: Remove this extr
             return io.data(beg=idx, end=idx + 1)
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
-        ScanImageTiffReader = _get_scanimage_reader()
+        """Get the video frames.
 
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        ScanImageTiffReader = _get_scanimage_reader()
         with ScanImageTiffReader(filename=str(self.file_path)) as io:
             return io.data(beg=start_frame, end=end_frame)
 

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -87,9 +87,51 @@ class TiffImagingExtractor(ImagingExtractor):
         }
 
     def get_frames(self, frame_idxs, channel: int = 0):
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._video[frame_idxs, ...]
 
     def get_video(self, start_frame=None, end_frame=None, channel: Optional[int] = 0) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self._video[start_frame:end_frame, ...]
 
     def get_image_size(self) -> Tuple[int, int]:

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -11,6 +11,7 @@ FrameSliceImagingExtractor
 from abc import ABC, abstractmethod
 from typing import Union, Optional, Tuple
 from copy import deepcopy
+import warnings
 
 import numpy as np
 
@@ -104,7 +105,7 @@ class ImagingExtractor(ABC):
         end_frame: int, optional
             End frame index (exclusive).
         channel: int, optional
-            Channel index.
+            Channel index. Deprecated: This parameter will be removed in August 2025.
 
         Returns
         -------
@@ -125,6 +126,12 @@ class ImagingExtractor(ABC):
 
         Where x is the columns width or and y is the rows or height.
         """
+        if channel != 0:
+            warnings.warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         pass
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> np.ndarray:
@@ -135,13 +142,19 @@ class ImagingExtractor(ABC):
         frame_idxs: array-like
             Indices of frames to return.
         channel: int, optional
-            Channel index.
+            Channel index. Deprecated: This parameter will be removed in August 2025.
 
         Returns
         -------
         frames: numpy.ndarray
             The video frames.
         """
+        if channel != 0:
+            warnings.warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         assert max(frame_idxs) <= self.get_num_frames(), "'frame_idxs' exceed number of frames"
         if np.all(np.diff(frame_idxs) == 0):
             return self.get_video(start_frame=frame_idxs[0], end_frame=frame_idxs[-1])

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -122,6 +122,26 @@ class MultiImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_dtype()
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> NumpyArray:
+        """Get specific video frames from indices.
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if channel != 0:
+            warnings.warn(
+                "The 'channel' parameter in get_frames() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if isinstance(frame_idxs, (int, np.integer)):
             frame_idxs = [frame_idxs]
         frame_idxs = np.array(frame_idxs)
@@ -150,7 +170,28 @@ class MultiImagingExtractor(ImagingExtractor):
     def get_video(
         self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
     ) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+        channel: int, optional
+            Channel index. Deprecated: This parameter will be removed in August 2025.
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
         if channel != 0:
+            warnings.warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             raise NotImplementedError(
                 f"MultiImagingExtractors for multiple channels have not yet been implemented! (Received '{channel}'."
             )

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -102,19 +102,10 @@ class TestNwbImagingExtractor(unittest.TestCase):
         expected_frames = self.video[frame_idxs, ...]
         np.testing.assert_array_almost_equal(frames_with_array, expected_frames)
 
-        # Test spikeinterface-like behavior for get_video
-        one_element_video_shape = nwb_imaging_extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
-        expected_shape = (1, image_size[0], image_size[1])
-        assert one_element_video_shape == expected_shape
-
         video = nwb_imaging_extractor.get_video()
         expected_video = self.video
 
         np.testing.assert_array_almost_equal(video, expected_video)
-
-    def test_get_frames_indexing_with_single_channel(self):
-        nwb_imaging_extractor = NwbImagingExtractor(file_path=self.file_path)
-        assert_get_frames_return_shape(imaging_extractor=nwb_imaging_extractor)
 
 
 if __name__ == "__main__":

--- a/tests/test_numpymemmapextractor.py
+++ b/tests/test_numpymemmapextractor.py
@@ -107,49 +107,6 @@ class TestNumpyMemmapExtractor(unittest.TestCase):
         )
         check_imaging_equal(imaging_extractor1=extractor, imaging_extractor2=roundtrip_extractor)
 
-    def test_get_frames_indexing_with_single_channel(self):
-        # Build a video structure
-        num_rows = 10
-        num_columns = 20
-        num_channels = 1
-        frame_axis = 0
-        rows_axis = 1
-        columns_axis = 2
-        channels_axis = 3
-        dtype = "uint16"
-
-        video_structure = VideoStructure(
-            num_rows=num_rows,
-            num_columns=num_columns,
-            num_channels=num_channels,
-            rows_axis=rows_axis,
-            columns_axis=columns_axis,
-            channels_axis=channels_axis,
-            frame_axis=frame_axis,
-        )
-
-        # Build a random video
-        memmap_shape = video_structure.build_video_shape(self.num_frames)
-        random_video = np.random.randint(low=0, high=256, size=memmap_shape).astype(dtype)
-
-        # Save it to memory
-        file_path = self.write_directory / f"video_test_shapes.dat"
-        file = np.memmap(file_path, dtype=dtype, mode="w+", shape=memmap_shape)
-        file[:] = random_video[:]
-        file.flush()
-        del file
-
-        # Load the video with the extactor
-        extractor = NumpyMemmapImagingExtractor(
-            file_path=file_path, video_structure=video_structure, sampling_frequency=1, dtype=dtype, offset=self.offset
-        )
-
-        assert_get_frames_return_shape(imaging_extractor=extractor)
-
-        one_element_video_shape = extractor.get_video(start_frame=0, end_frame=1, channel=0).shape
-        expected_shape = (1, num_rows, num_columns)
-        assert one_element_video_shape == expected_shape
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Courtesy of cline

Should fix #386