### PR TITLE
Deprecate `get_number_of_channels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Deprecations
 * The 'channel' parameter in get_frames() and get_video() methods is deprecated and will be removed in August 2025.  [#388](https://github.com/catalystneuro/roiextractors/pull/388)
+* Removed get_num_channels from the ImagingExtractor abstract class. Implementations remain in concrete classes.
 
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Deprecations
 * The 'channel' parameter in get_frames() and get_video() methods is deprecated and will be removed in August 2025.  [#388](https://github.com/catalystneuro/roiextractors/pull/388)
-* Removed get_num_channels from the ImagingExtractor abstract class. Implementations remain in concrete classes.
+* Removed get_num_channels from the ImagingExtractor abstract class. Implementations remain in concrete classes. [#392](https://github.com/catalystneuro/roiextractors/pull/392)
 
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Deprecations
 * The 'channel' parameter in get_frames() and get_video() methods is deprecated and will be removed in August 2025.  [#388](https://github.com/catalystneuro/roiextractors/pull/388)
-* Removed get_num_channels from the ImagingExtractor abstract class. Implementations remain in concrete classes. [#392](https://github.com/catalystneuro/roiextractors/pull/392)
+* Removed get_num_channels from the base ImagingExtractor as an abstract class. Implementations remain in concrete classes until deprecation on August 2025 [#392](https://github.com/catalystneuro/roiextractors/pull/392)
 
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -110,17 +110,6 @@ class MemmapImagingExtractor(ImagingExtractor):
         pass
 
     def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
         warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -110,6 +110,17 @@ class MemmapImagingExtractor(ImagingExtractor):
         pass
 
     def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
         warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -110,6 +110,11 @@ class MemmapImagingExtractor(ImagingExtractor):
         pass
 
     def get_num_channels(self) -> int:
+        warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._num_channels
 
     def get_dtype(self) -> DtypeType:

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -144,6 +144,11 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_num_channels(self):
+        warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._num_channels
 
     def get_channel_names(self):

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -144,17 +144,6 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_num_channels(self):
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
         warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -144,6 +144,17 @@ class TiffImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_num_channels(self):
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
         warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -71,6 +71,24 @@ class ImagingExtractor(ABC):
         """
         pass
 
+    def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
+        warnings.warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     def get_dtype(self) -> DtypeType:
         """Get the data type of the video.
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -71,17 +71,6 @@ class ImagingExtractor(ABC):
         """
         pass
 
-    @abstractmethod
-    def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-        """
-        pass
-
     def get_dtype(self) -> DtypeType:
         """Get the data type of the video.
 
@@ -357,4 +346,9 @@ class FrameSliceImagingExtractor(ImagingExtractor):
         return self._parent_imaging.get_channel_names()
 
     def get_num_channels(self) -> int:
+        warnings.warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._parent_imaging.get_num_channels()

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -346,6 +346,17 @@ class FrameSliceImagingExtractor(ImagingExtractor):
         return self._parent_imaging.get_channel_names()
 
     def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
         warnings.warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -255,6 +255,17 @@ class MultiImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
         warnings.warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -255,4 +255,9 @@ class MultiImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
+        warnings.warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._imaging_extractors[0].get_num_channels()

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -255,17 +255,6 @@ class MultiImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
         warnings.warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -1,6 +1,7 @@
 """Base class definition for volumetric imaging extractors."""
 
 from typing import Tuple, List, Iterable, Optional
+import warnings
 import numpy as np
 
 from .extraction_tools import ArrayType, DtypeType
@@ -164,6 +165,11 @@ class VolumetricImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
+        warnings.warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._imaging_extractors[0].get_num_channels()
 
     def get_dtype(self) -> DtypeType:

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -165,6 +165,17 @@ class VolumetricImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
         warnings.warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -165,17 +165,6 @@ class VolumetricImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_channel_names()
 
     def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
         warnings.warn(
             "get_num_channels() is deprecated and will be removed in or after August 2025.",
             DeprecationWarning,


### PR DESCRIPTION
Should fix #391

This removes the method from the base class so new classes don't need to implement it and add deprecation warnings on the actual use cases.