### PR TITLE
Add Thor extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming (v0.5.11)
 
 ### Features
-* Added ThorTiffImagingExtractor for reading TIFF files produced via Thor
+* Added ThorTiffImagingExtractor for reading TIFF files produced via Thor [#395](https://github.com/catalystneuro/roiextractors/pull/395)
 
 ### Fixes
 * Use tifffile.imwrite instead of tifffile.imsave for TiffImagingExtractor: [#390](https://github.com/catalystneuro/roiextractors/pull/390)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming (v0.5.11)
 
 ### Features
+* Added ThorTiffImagingExtractor for reading TIFF files produced via Thor
 
 ### Fixes
 * Use tifffile.imwrite instead of tifffile.imsave for TiffImagingExtractor: [#390](https://github.com/catalystneuro/roiextractors/pull/390)

--- a/src/roiextractors/extractorlist.py
+++ b/src/roiextractors/extractorlist.py
@@ -23,6 +23,7 @@ from .extractors.tiffimagingextractors import (
     BrukerTiffMultiPlaneImagingExtractor,
     BrukerTiffSinglePlaneImagingExtractor,
     MicroManagerTiffImagingExtractor,
+    ThorTiffImagingExtractor,
 )
 from .extractors.sbximagingextractor import SbxImagingExtractor
 from .extractors.inscopixextractors import InscopixImagingExtractor
@@ -45,6 +46,7 @@ imaging_extractor_full_list = [
     BrukerTiffMultiPlaneImagingExtractor,
     BrukerTiffSinglePlaneImagingExtractor,
     MicroManagerTiffImagingExtractor,
+    ThorTiffImagingExtractor,
     MiniscopeImagingExtractor,
     NwbImagingExtractor,
     SbxImagingExtractor,

--- a/src/roiextractors/extractors/tiffimagingextractors/__init__.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/__init__.py
@@ -10,6 +10,8 @@ brukertiffimagingextractor
     Specialized extractor for reading TIFF files produced via Bruker.
 micromanagertiffimagingextractor
     Specialized extractor for reading TIFF files produced via Micro-Manager.
+thortiffimagingextractor
+    Specialized extractor for reading TIFF files produced via Thor.
 
 Classes
 -------
@@ -31,6 +33,8 @@ BrukerTiffSinglePlaneImagingExtractor
     Specialized extractor for reading TIFF files produced via Bruker.
 MicroManagerTiffImagingExtractor
     Specialized extractor for reading TIFF files produced via Micro-Manager.
+ThorTiffImagingExtractor
+    Specialized extractor for reading TIFF files produced via Thor.
 """
 
 from .tiffimagingextractor import TiffImagingExtractor
@@ -43,3 +47,4 @@ from .scanimagetiffimagingextractor import (
 )
 from .brukertiffimagingextractor import BrukerTiffMultiPlaneImagingExtractor, BrukerTiffSinglePlaneImagingExtractor
 from .micromanagertiffimagingextractor import MicroManagerTiffImagingExtractor
+from .thortiffimagingextractor import ThorTiffImagingExtractor

--- a/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
@@ -152,7 +152,7 @@ class ThorTiffImagingExtractor(ImagingExtractor):
             self._channel_names = []
 
     @staticmethod
-    def _parse_ome_metadata(metadata_string: str) -> ET._Element:
+    def _parse_ome_metadata(metadata_string: str):
         """Parse an OME metadata string using lxml.etree.
 
         Removes XML comments if present and attempts to parse as bytes first.

--- a/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
@@ -1,0 +1,261 @@
+"""Extractor for Thor TIFF files."""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+from collections import defaultdict, namedtuple
+import warnings
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import tifffile
+
+from ...imagingextractor import ImagingExtractor
+
+
+class ThorTiffImagingExtractor(ImagingExtractor):
+    """
+    An ImagingExtractor for multiple TIFF files using OME metadata.
+
+    This extractor builds a mapping between the T (time) dimension and the corresponding
+    pages/IFD or the tiff files using a named tuple structure:
+
+    For each time frame (T), we record a list of PageMapping objects that corresponds to the
+    pages of the tiff file that contain the image data for that frame.
+
+    Each PageMapping object contains:
+      - page_index: The index of the page in the TIFF file (which holds the complete X and Y image data),
+      - channel_index: The coordinate along the channel (C) axis (or None if absent),
+      - depth_index: The coordinate along the depth (Z) axis (or None if absent).
+
+    When get_frames() is called, the mapping is used to load only the pages for the requested
+    frames into a preallocated NumPy array.
+
+    Note: According to the OME specification (see
+    https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Pixels_DimensionOrder),
+    the spatial dimensions (X and Y) are always stored on a single page.
+    """
+
+    extractor_name = "ThorTiffImaging"
+    is_writable = False
+
+    # Named tuple to hold page mapping details.
+    PageMapping = namedtuple("PageMapping", ["page_index", "channel_index", "depth_index"])
+
+    def __init__(self, file_path: Union[str, Path], channel_name: Optional[str] = None):
+        """Create a ThorTiffImagingExtractor instance from a TIFF file."""
+        super().__init__()
+        self.file_path = Path(file_path)
+        self.folder_path = self.file_path.parent
+        self.channel_name = channel_name
+        self._data = None  # Mapping pages on demand
+
+        # Load Experiment.xml metadata if available.
+        self._parse_experiment_xml()
+
+        # Open the TIFF file to extract OME metadata and series information.
+        with tifffile.TiffFile(self.file_path) as tiff_reader:
+            self._ome_metadata = tiff_reader.ome_metadata
+            ome_root = self._parse_ome_metadata(self._ome_metadata)
+            pixels_element = ome_root.find(".//{*}Pixels")
+            if pixels_element is None:
+                raise ValueError("Could not find 'Pixels' element in OME metadata.")
+
+            self._num_channels = int(pixels_element.get("SizeC", "1"))
+            self._num_frames = int(pixels_element.get("SizeT", "1"))
+            self._num_rows = int(pixels_element.get("SizeY"))
+            self._num_columns = int(pixels_element.get("SizeX"))
+            self._num_z = int(pixels_element.get("SizeZ", "1"))
+            self._dimension_order = pixels_element.get("DimensionOrder")
+
+            # Series is a concept from the tifffile library.
+            # It indexes all the data across pages and files
+            series = tiff_reader.series[0]
+            self._dtype = series.dtype
+            number_of_pages = len(series)
+            series_axes = (
+                series.axes
+            )  # "XYZTC" or "XYCZT" Note this is different from OME metadata as this is data layout
+            series_shape = series.shape
+
+        # Determine non-spatial axes (remove X and Y).
+        non_spatial_axes = [axis for axis in series_axes if axis not in ("X", "Y")]
+        non_spatial_shape = [dim for axis, dim in zip(series_axes, series_shape) if axis not in ("X", "Y")]
+
+        if "T" not in non_spatial_axes:
+            raise ValueError("The TIFF file must have a T (time) dimension. Image stack mode is not supported.")
+
+        total_expected_pages = np.prod(non_spatial_shape)
+        if total_expected_pages != number_of_pages:
+            warnings.warn(f"Expected {total_expected_pages} pages but found {number_of_pages} pages in the series.")
+
+        # Identify axis indices.
+        self._time_axis_index = non_spatial_axes.index("T")
+        self._z_axis_index = non_spatial_axes.index("Z") if "Z" in non_spatial_axes else None
+        self._channel_axis_index = non_spatial_axes.index("C") if "C" in non_spatial_axes else None
+
+        self._non_spatial_axes = non_spatial_axes
+        self._non_spatial_shape = non_spatial_shape
+
+        # Build the mapping from each time frame (T) to its corresponding pages.
+        self._frame_page_mapping: Dict[int, List[ThorTiffImagingExtractor.PageMapping]] = defaultdict(list)
+        for page_index in range(number_of_pages):
+            page_multi_index = np.unravel_index(page_index, non_spatial_shape, order="C")
+            time_index = page_multi_index[self._time_axis_index]
+            channel_index = page_multi_index[self._channel_axis_index] if self._channel_axis_index is not None else None
+            depth_index = page_multi_index[self._z_axis_index] if self._z_axis_index is not None else None
+            mapping_entry = ThorTiffImagingExtractor.PageMapping(
+                page_index=page_index, channel_index=channel_index, depth_index=depth_index
+            )
+            self._frame_page_mapping[time_index].append(mapping_entry)
+
+        self._kwargs = {"file_path": str(file_path)}
+
+    def _parse_experiment_xml(self) -> None:
+        """Parse Experiment.xml and extract metadata.
+
+        Extract metadata such as frame rate and channel names from the Experiment.xml file.
+        """
+        experiment_xml_path = self.folder_path / "Experiment.xml"
+        if experiment_xml_path.exists():
+            experiment_tree = ET.parse(str(experiment_xml_path))
+            experiment_root = experiment_tree.getroot()
+            lsm_element = experiment_root.find(".//LSM")
+            if lsm_element is not None:
+                frame_rate = lsm_element.attrib.get("frameRate")
+                self._sampling_frequency = float(frame_rate) if frame_rate is not None else None
+            else:
+                raise ValueError("Could not find 'LSM' element in Experiment.xml which contains the frame rate.")
+
+            wavelength_elements = experiment_root.findall(".//Wavelength")
+            self._channel_names = [
+                wavelength.attrib.get("name") for wavelength in wavelength_elements if "name" in wavelength.attrib
+            ]
+            if self.channel_name is not None and self.channel_name not in self._channel_names:
+                raise ValueError(
+                    f"Channel '{self.channel_name}' not available. Available channels: {self._channel_names}"
+                )
+            # Set channel filter if a channel name is provided.
+            if self.channel_name is not None:
+                self._channel_index_for_filter = None
+                for index, name in enumerate(self._channel_names):
+                    if self.channel_name in name:
+                        self._channel_index_for_filter = index
+                        break
+                if self._channel_index_for_filter is None:
+                    raise ValueError(f"Channel '{self.channel_name}' not found in Experiment.xml.")
+                # Update channel names and count based on the filter.
+                self._channel_names = [self._channel_names[self._channel_index_for_filter]]
+                self._num_channels = 1
+        else:
+            # If Experiment.xml is missing, set defaults.
+            self._sampling_frequency = None
+            self._channel_names = []
+
+    @staticmethod
+    def _parse_ome_metadata(metadata_string: str) -> ET._Element:
+        """Parse an OME metadata string using lxml.etree.
+
+        Removes XML comments if present and attempts to parse as bytes first.
+
+        In the old version of ome tiff the metadata is stored as a comment. In the new version, the metadata
+        is stored as an utf-8 encoded xml string.
+        """
+        if metadata_string.lstrip().startswith("<!--"):
+            metadata_string = metadata_string.replace("<!--", "").replace("-->", "")
+        try:
+            return ET.fromstring(metadata_string.encode("utf-8"))
+        except ValueError:
+            return ET.fromstring(metadata_string)
+
+    def get_frames(self, frame_idxs: List[int]) -> np.ndarray:
+        """
+        Get specific frames by their time indices.
+
+        Parameters
+        ----------
+        frame_idxs : List[int]
+            List of time/frame indices to retrieve.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape (n_frames, height, width) if no depth, or
+            (n_frames, height, width, n_z) if a Z dimension exists.
+        """
+        with tifffile.TiffFile(self.file_path) as tiff_reader:
+            series = tiff_reader.series[0]
+            data_type = series.dtype
+            image_height = self._num_rows
+            image_width = self._num_columns
+
+            has_z_dimension = self._z_axis_index is not None and self._num_z > 1
+            number_of_z_planes = self._num_z if has_z_dimension else 1
+
+            n_frames = len(frame_idxs)
+            output_shape = (
+                (n_frames, image_height, image_width, number_of_z_planes)
+                if has_z_dimension
+                else (n_frames, image_height, image_width)
+            )
+            output_array = np.empty(output_shape, dtype=data_type)
+
+            for frame_counter, frame_idx in enumerate(frame_idxs):
+                if frame_idx not in self._frame_page_mapping:
+                    raise ValueError(f"No pages found for frame {frame_idx}.")
+                page_mappings = self._frame_page_mapping[frame_idx]
+
+                # Filter by channel if a channel name was provided.
+                if self._channel_axis_index is not None and self.channel_name is not None:
+                    filter_index = self._channel_index_for_filter
+                    page_mappings = [m for m in page_mappings if m.channel_index == filter_index]
+
+                if has_z_dimension:
+                    page_mappings.sort(key=lambda entry: entry.depth_index)
+                    if len(page_mappings) != number_of_z_planes:
+                        raise ValueError(
+                            f"Expected {number_of_z_planes} pages for frame {frame_idx} but got {len(page_mappings)}."
+                        )
+                    for depth_counter, mapping_entry in enumerate(page_mappings):
+                        page_data = series.pages[mapping_entry.page_index].asarray()
+                        output_array[frame_counter, :, :, depth_counter] = page_data
+                else:
+                    if len(page_mappings) != 1:
+                        raise ValueError(f"Expected 1 page for frame {frame_idx} but got {len(page_mappings)}.")
+                    single_page_index = page_mappings[0].page_index
+                    page_data = series.pages[single_page_index].asarray()
+                    output_array[frame_counter, :, :] = page_data
+
+        return output_array
+
+    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
+        """Get a range of frames."""
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self._num_frames
+        frame_indices = list(range(start_frame, end_frame))
+        return self.get_frames(frame_indices)
+
+    def get_image_size(self) -> Tuple[int, int]:
+        """Return the image dimensions (height, width)."""
+        return self._num_rows, self._num_columns
+
+    def get_num_frames(self) -> int:
+        """Return the number of frames (time points)."""
+        return self._num_frames
+
+    def get_sampling_frequency(self) -> Optional[float]:
+        """Return the sampling frequency, if available."""
+        return self._sampling_frequency
+
+    def get_num_channels(self) -> int:
+        """Return the number of channels."""
+        return self._num_channels
+
+    def get_channel_names(self) -> List[str]:
+        """Return the channel names."""
+        return self._channel_names
+
+    def get_dtype(self):
+        """Return the data type of the video."""
+        return self._dtype

--- a/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
@@ -7,7 +7,6 @@ import warnings
 import xml.etree.ElementTree as ET
 
 import numpy as np
-import tifffile
 
 from ...imagingextractor import ImagingExtractor
 
@@ -61,6 +60,8 @@ class ThorTiffImagingExtractor(ImagingExtractor):
 
         # Open the TIFF file to extract OME metadata and series information.
         # Keep the file reference open instead of using a context manager
+        import tifffile
+
         self._tiff_reader = tifffile.TiffFile(self.file_path)
         self._ome_metadata = self._tiff_reader.ome_metadata
         ome_root = self._parse_ome_metadata(self._ome_metadata)

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -59,9 +59,7 @@ class BaseTestFrameSlicesegmentation(TestCase):
         assert self.frame_sliced_segmentation.get_num_rois() == 10
 
     def test_get_accepted_list(self):
-        return assert_array_equal(
-            x=self.frame_sliced_segmentation.get_accepted_list(), y=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        )
+        return assert_array_equal(self.frame_sliced_segmentation.get_accepted_list(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
     def test_get_rejected_list(self):
         return assert_array_equal(self.frame_sliced_segmentation.get_rejected_list(), [])
@@ -91,7 +89,7 @@ class BaseTestFrameSlicesegmentation(TestCase):
     @parameterized.expand([param(name="mean"), param(name="correlation")], name_func=segmentation_name_function)
     def test_get_image(self, name: str):
         assert_array_equal(
-            x=self.frame_sliced_segmentation.get_image(name=name), y=self.toy_segmentation_example.get_image(name=name)
+            self.frame_sliced_segmentation.get_image(name=name), self.toy_segmentation_example.get_image(name=name)
         )
 
 

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -102,3 +102,12 @@ class TestThorTiffImagingExtractor:
 
         # Test that channel names were extracted from Experiment.xml
         assert len(self.extractor.get_channel_names()) > 0
+
+        date_value = self.extractor._experiment_xml_dict["ThorImageExperiment"]["Date"]
+        from datetime import datetime
+
+        dt_from_utime = datetime.fromtimestamp(int(date_value["@uTime"]))
+
+        # Assert that the date extracted from Experiment.xml matches the expected datetime
+        expected_datetime = datetime(2023, 10, 18, 11, 39, 19)
+        assert dt_from_utime == expected_datetime

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -1,0 +1,115 @@
+"""Tests for ThorTiffImagingExtractor."""
+
+import os
+import pytest
+from pathlib import Path
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import tifffile
+
+from roiextractors import ThorTiffImagingExtractor
+from .setup_paths import OPHYS_DATA_PATH
+
+
+# Path to the test data
+TEST_DIR = Path(
+    "/home/heberto/neuroconv_testing_data/ophys_testing_data/imaging_datasets/ThorlabsTiff/single_channel_single_plane/20231018-002"
+)
+FILE_PATH = TEST_DIR / "ChanA_001_001_001_001.tif"
+
+
+class TestThorTiffImagingExtractor:
+    """Test ThorTiffImagingExtractor."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up the test."""
+        if not FILE_PATH.exists():
+            pytest.skip(f"Test file {FILE_PATH} not found. Skipping tests.")
+
+        # Create the extractor
+        cls.extractor = ThorTiffImagingExtractor(file_path=FILE_PATH)
+
+        # Load the test data for comparison
+        cls.test_data = tifffile.imread(FILE_PATH)
+
+    def test_thor_tiff_extractor_image_size(self):
+        """Test the image size property."""
+        assert self.extractor.get_image_size() == (self.test_data.shape[1], self.test_data.shape[2])
+
+    def test_thor_tiff_extractor_num_frames(self):
+        """Test the number of frames property."""
+        assert self.extractor.get_num_frames() == self.test_data.shape[0]
+
+    def test_thor_tiff_extractor_sampling_frequency(self):
+        """Test the sampling frequency property."""
+        assert self.extractor.get_sampling_frequency() is not None
+        assert isinstance(self.extractor.get_sampling_frequency(), float)
+
+    def test_thor_tiff_extractor_channel_names(self):
+        """Test the channel names property."""
+        assert self.extractor.get_channel_names() is not None
+        assert isinstance(self.extractor.get_channel_names(), list)
+
+    def test_thor_tiff_extractor_num_channels(self):
+        """Test the number of channels property."""
+        assert self.extractor.get_num_channels() == 1
+
+    def test_thor_tiff_extractor_dtype(self):
+        """Test the data type property."""
+        assert self.extractor.get_dtype() == self.test_data.dtype
+
+    def test_thor_tiff_extractor_get_video(self):
+        """Test the get_video method."""
+        video = self.extractor.get_video()
+        assert video.shape[0] == self.test_data.shape[0]  # Same number of frames
+        assert video.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+        assert video.dtype == self.test_data.dtype  # Same data type
+
+        # Test with start and end frame
+        start_frame = 0
+        end_frame = 2
+        video_slice = self.extractor.get_video(start_frame=start_frame, end_frame=end_frame)
+        assert video_slice.shape[0] == end_frame - start_frame  # Correct number of frames
+        assert video_slice.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+
+    def test_thor_tiff_extractor_get_frames(self):
+        """Test the get_frames method."""
+        frame_idxs = [0, 1, 2]
+        frames = self.extractor.get_frames(frame_idxs=frame_idxs)
+        assert frames.shape[0] == len(frame_idxs)  # Correct number of frames
+        assert frames.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+
+        # Test with non-consecutive frames
+        frame_idxs = [0, 2]
+        frames = self.extractor.get_frames(frame_idxs=frame_idxs)
+        assert frames.shape[0] == len(frame_idxs)  # Correct number of frames
+        assert frames.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+
+    def test_experiment_xml(self):
+        """Test parsing of Experiment.xml."""
+        # Test that sampling frequency was extracted from Experiment.xml
+        assert self.extractor.get_sampling_frequency() is not None
+
+        # Test that channel names were extracted from Experiment.xml
+        assert len(self.extractor.get_channel_names()) > 0
+
+    def test_multiple_files(self):
+        """Test handling of multiple files in the same directory."""
+        # This test assumes there are multiple .tif files in the test directory
+        tif_files = list(TEST_DIR.glob("*.tif"))
+        if len(tif_files) <= 1:
+            pytest.skip("Not enough TIFF files for multiple file test.")
+
+        # Test with the first file
+        imaging1 = ThorTiffImagingExtractor(file_path=tif_files[0])
+
+        # Test with the second file
+        imaging2 = ThorTiffImagingExtractor(file_path=tif_files[1])
+
+        # Both should have the same properties except possibly number of frames
+        assert imaging1.get_image_size() == imaging2.get_image_size()
+        assert imaging1.get_sampling_frequency() == imaging2.get_sampling_frequency()
+        assert imaging1.get_channel_names() == imaging2.get_channel_names()
+        assert imaging1.get_num_channels() == imaging2.get_num_channels()

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -13,9 +13,7 @@ from .setup_paths import OPHYS_DATA_PATH
 
 
 # Path to the test data
-TEST_DIR = Path(
-    "/home/heberto/neuroconv_testing_data/ophys_testing_data/imaging_datasets/ThorlabsTiff/single_channel_single_plane/20231018-002"
-)
+TEST_DIR = OPHYS_DATA_PATH / "imaging_datasets" / "ThorlabsTiff" / "single_channel_single_plane" / "20231018-002"
 FILE_PATH = TEST_DIR / "ChanA_001_001_001_001.tif"
 
 
@@ -51,10 +49,6 @@ class TestThorTiffImagingExtractor:
         """Test the channel names property."""
         assert self.extractor.get_channel_names() is not None
         assert isinstance(self.extractor.get_channel_names(), list)
-
-    def test_thor_tiff_extractor_num_channels(self):
-        """Test the number of channels property."""
-        assert self.extractor.get_num_channels() == 1
 
     def test_thor_tiff_extractor_dtype(self):
         """Test the data type property."""
@@ -97,7 +91,6 @@ class TestThorTiffImagingExtractor:
 
     def test_multiple_files(self):
         """Test handling of multiple files in the same directory."""
-        # This test assumes there are multiple .tif files in the test directory
         tif_files = list(TEST_DIR.glob("*.tif"))
         if len(tif_files) <= 1:
             pytest.skip("Not enough TIFF files for multiple file test.")
@@ -112,4 +105,3 @@ class TestThorTiffImagingExtractor:
         assert imaging1.get_image_size() == imaging2.get_image_size()
         assert imaging1.get_sampling_frequency() == imaging2.get_sampling_frequency()
         assert imaging1.get_channel_names() == imaging2.get_channel_names()
-        assert imaging1.get_num_channels() == imaging2.get_num_channels()

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -88,20 +88,3 @@ class TestThorTiffImagingExtractor:
 
         # Test that channel names were extracted from Experiment.xml
         assert len(self.extractor.get_channel_names()) > 0
-
-    def test_multiple_files(self):
-        """Test handling of multiple files in the same directory."""
-        tif_files = list(TEST_DIR.glob("*.tif"))
-        if len(tif_files) <= 1:
-            pytest.skip("Not enough TIFF files for multiple file test.")
-
-        # Test with the first file
-        imaging1 = ThorTiffImagingExtractor(file_path=tif_files[0])
-
-        # Test with the second file
-        imaging2 = ThorTiffImagingExtractor(file_path=tif_files[1])
-
-        # Both should have the same properties except possibly number of frames
-        assert imaging1.get_image_size() == imaging2.get_image_size()
-        assert imaging1.get_sampling_frequency() == imaging2.get_sampling_frequency()
-        assert imaging1.get_channel_names() == imaging2.get_channel_names()

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -1,8 +1,6 @@
-"""Tests for ThorTiffImagingExtractor."""
-
-import os
 import pytest
 from pathlib import Path
+from datetime import datetime, timezone
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -104,10 +102,11 @@ class TestThorTiffImagingExtractor:
         assert len(self.extractor.get_channel_names()) > 0
 
         date_value = self.extractor._experiment_xml_dict["ThorImageExperiment"]["Date"]
-        from datetime import datetime
 
-        dt_from_utime = datetime.fromtimestamp(int(date_value["@uTime"]))
+        unix_timestamp = int(date_value["@uTime"])
+        assert unix_timestamp == 1697650759
+        datetime_utc = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
 
         # Assert that the date extracted from Experiment.xml matches the expected datetime
-        expected_datetime = datetime(2023, 10, 18, 11, 39, 19)
-        assert dt_from_utime == expected_datetime
+        expected_datetime = datetime(2023, 10, 18, 17, 39, 19, tzinfo=timezone.utc)
+        assert datetime_utc == expected_datetime

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -61,12 +61,18 @@ class TestThorTiffImagingExtractor:
         assert video.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
         assert video.dtype == self.test_data.dtype  # Same data type
 
+        # Compare with the entire test_data
+        assert_array_equal(video, self.test_data)
+
         # Test with start and end frame
         start_frame = 0
         end_frame = 2
         video_slice = self.extractor.get_video(start_frame=start_frame, end_frame=end_frame)
         assert video_slice.shape[0] == end_frame - start_frame  # Correct number of frames
         assert video_slice.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+
+        # Compare with the corresponding slice of test_data
+        assert_array_equal(video_slice, self.test_data[start_frame:end_frame])
 
     def test_thor_tiff_extractor_get_frames(self):
         """Test the get_frames method."""
@@ -75,11 +81,19 @@ class TestThorTiffImagingExtractor:
         assert frames.shape[0] == len(frame_idxs)  # Correct number of frames
         assert frames.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
 
+        # Compare with frames extracted directly from the test_data
+        for i, frame_idx in enumerate(frame_idxs):
+            assert_array_equal(frames[i], self.test_data[frame_idx])
+
         # Test with non-consecutive frames
         frame_idxs = [0, 2]
         frames = self.extractor.get_frames(frame_idxs=frame_idxs)
         assert frames.shape[0] == len(frame_idxs)  # Correct number of frames
         assert frames.shape[1:] == self.test_data.shape[1:]  # Same image dimensions
+
+        # Compare with frames extracted directly from the test_data
+        for i, frame_idx in enumerate(frame_idxs):
+            assert_array_equal(frames[i], self.test_data[frame_idx])
 
     def test_experiment_xml(self):
         """Test parsing of Experiment.xml."""


### PR DESCRIPTION
This is like #322 but has some improvements:
* It gets the file paths from the ome specification embedded within the `ImageDescription` at the IFD of the tiff file.
* Handles the multi channel case (I used and tested this on the Cohen conversion) [I requested them to stub some of their data, let's see what they say].
* It should handle the volumetric case as well (not test data for this unfortunately)
* It parses the accompanying `Experiment.xml` to get the sampling frequency.

I stubbed some files and there is a PR on the gin repo:
https://gin.g-node.org/CatalystNeuro/ophys_testing_data/pulls/25
[merged]

 