### PR TITLE
Add correct binary prefixes to text representation of ImaginExtractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)
-* Added `__repr__` and  methods to ImagingExtractor for better display in terminals and Jupyter notebooks [#393](https://github.com/catalystneuro/roiextractors/pull/393)
+* Added `__repr__` and  methods to ImagingExtractor for better display in terminals and Jupyter notebooks [#393](https://github.com/catalystneuro/roiextractors/pull/393) [#396](https://github.com/catalystneuro/roiextractors/pull/396)
 
 
 # v0.5.10 (November 6th, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)
 * Added `__repr__` and  methods to ImagingExtractor for better display in terminals and Jupyter notebooks [#393](https://github.com/catalystneuro/roiextractors/pull/393) and [#396](https://github.com/catalystneuro/roiextractors/pull/396)
-* Removed deprecated np.product from the library [#397](https://github.com/catalystneuro/roiextractors/pull/397) 
+* Removed deprecated np.product from the library [#397](https://github.com/catalystneuro/roiextractors/pull/397)
 
 # v0.5.10 (November 6th, 2024)
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -84,18 +84,24 @@ class ImagingExtractor(ABC):
             return f"{hours:.1f}h"
 
     def _convert_bytes_to_str(self, size_in_bytes):
-        """Convert bytes to a human-readable string."""
+        """
+        Convert bytes to a human-readable string.
+
+        Convert bytes to a human-readable string using IEC binary prefixes (KiB, MiB, GiB).
+        Note that RAM memory is typically measured in IEC binary prefixes  while disk storage is typically
+        measured in SI binary prefixes.
+        """
         if size_in_bytes < 1024:
             return f"{size_in_bytes}B"
         elif size_in_bytes < 1024 * 1024:
             size_kb = size_in_bytes / 1024
-            return f"{size_kb:.1f}KB"
+            return f"{size_kb:.1f}KiB"
         elif size_in_bytes < 1024 * 1024 * 1024:
             size_mb = size_in_bytes / (1024 * 1024)
-            return f"{size_mb:.1f}MB"
+            return f"{size_mb:.1f}MiB"
         else:
             size_gb = size_in_bytes / (1024 * 1024 * 1024)
-            return f"{size_gb:.1f}GB"
+            return f"{size_gb:.1f}GiB"
 
     @abstractmethod
     def get_image_size(self) -> Tuple[int, int]:


### PR DESCRIPTION
I forgot to add the right prefix in #393. I also added clarifying comments on the docstring of the respective function.