### PR TITLE
Remove deprecated numpy methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Improvements
 * Use `pyproject.toml` for project metadata and installation requirements [#382](https://github.com/catalystneuro/roiextractors/pull/382)
 * Added `__repr__` and  methods to ImagingExtractor for better display in terminals and Jupyter notebooks [#393](https://github.com/catalystneuro/roiextractors/pull/393)
-
+* Removed deprecated np.product from the library [#397](https://github.com/catalystneuro/roiextractors/pull/397)
 
 # v0.5.10 (November 6th, 2024)
 

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -177,7 +177,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             type_size = np.dtype(dtype).itemsize
 
             n_channels = imaging.get_num_channels()
-            pixels_per_frame = n_channels * np.product(imaging.get_image_size())
+            pixels_per_frame = n_channels * np.prod(imaging.get_image_size())
             bytes_per_frame = type_size * pixels_per_frame
             frames_in_buffer = buffer_size_in_bytes // bytes_per_frame
 

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -127,7 +127,7 @@ class SbxImagingExtractor(ImagingExtractor):
             info["resfreq"] / info["config"]["lines"] * (2 - info["scanmode"]) * info["fov_repeats"]
         )
         # SIMA:
-        info["nsamples"] = info["sz"][1] * info["recordsPerBuffer"] * info["nChan"] * 2
+        info["nsamples"] = int(info["sz"][1]) * int(info["recordsPerBuffer"]) * int(info["nChan"] * 2)
         # SIMA:
         if ("volscan" in info and info["volscan"] > 0) or ("volscan" not in info and len(info.get("otwave", []))):
             info["nplanes"] = len(info["otwave"])
@@ -135,7 +135,7 @@ class SbxImagingExtractor(ImagingExtractor):
             info["nplanes"] = 1
         # SIMA:
         if info.get("scanbox_version", -1) >= 2:
-            info["max_idx"] = os.path.getsize(self.sbx_file_path) // info["nsamples"] - 1
+            info["max_idx"] = os.path.getsize(self.sbx_file_path) // int(info["nsamples"]) - 1
         else:
             info["max_idx"] = os.path.getsize(self.sbx_file_path) // info["bytesPerBuffer"] * factor - 1
         # SIMA: Fix for old scanbox versions
@@ -152,7 +152,7 @@ class SbxImagingExtractor(ImagingExtractor):
             The numpy array containing the data from the `.sbx` file.
         """
         nrows = self._info["recordsPerBuffer"]
-        ncols = self._info["sz"][1]
+        ncols = int(self._info["sz"][1])
         nchannels = self._info["nChan"]
         nplanes = self._info["nplanes"]
         nframes = (self._info["max_idx"] + 1) // nplanes

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -128,7 +128,7 @@ def test_frame_slicing_segmentation_get_roi_pixel_masks_override():
     toy_segmentation_example.get_roi_pixel_masks = MethodType(get_roi_pixel_masks_override, toy_segmentation_example)
 
     frame_sliced_segmentation = toy_segmentation_example.frame_slice(start_frame=start_frame, end_frame=end_frame)
-    np.testing.assert_array_equal(x=frame_sliced_segmentation.get_roi_pixel_masks(), y=np.array([1, 2, 3]))
+    np.testing.assert_array_equal(frame_sliced_segmentation.get_roi_pixel_masks(), np.array([1, 2, 3]))
 
 
 if __name__ == "__main__":

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -64,7 +64,7 @@ class BaseTestFrameSlicesegmentation(TestCase):
         )
 
     def test_get_rejected_list(self):
-        return assert_array_equal(x=self.frame_sliced_segmentation.get_rejected_list(), y=[])
+        return assert_array_equal(self.frame_sliced_segmentation.get_rejected_list(), [])
 
     @parameterized.expand(
         [param(name="raw"), param(name="dff"), param(name="neuropil"), param(name="deconvolved")],

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -107,7 +107,7 @@ class TestMultiImagingExtractor(TestCase):
             ],
             axis=0,
         )
-        assert_array_equal(x=test_video, y=expected_video)
+        assert_array_equal(test_video, expected_video)
 
     def test_get_video_single_frame(self):
         test_frames = self.multi_imaging_extractor.get_video(start_frame=10, end_frame=11)


### PR DESCRIPTION
This is causing failures and warnings on the CI.

See also:
https://github.com/catalystneuro/neuroconv/pull/1235