### PR TITLE
Improve scan image number of channel detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#395](https://github.com/catalystneuro/roiextractors/pull/395)
+* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#401](https://github.com/catalystneuro/roiextractors/pull/401)
 ### Deprecations
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-
+* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#395](https://github.com/catalystneuro/roiextractors/pull/395)
 ### Deprecations
 
 ### Improvements

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -121,6 +121,8 @@ def parse_metadata(metadata: dict) -> dict:
         num_planes = 1
         frames_per_slice = 1
 
+    # `channelSave` indicates whether the channel is saved. Note that a channel might not be saved even if it is active.
+    # We check `channelSave` first but keep the `channelsActive` check for backward compatibility.
     channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsActive"]
     for channel_availability in channel_availability_keys:
         if channel_availability in metadata.keys():

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -121,7 +121,7 @@ def parse_metadata(metadata: dict) -> dict:
         num_planes = 1
         frames_per_slice = 1
 
-    channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsave", "SI.hChannels.channelsActive"]
+    channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsActive"]
     for channel_availability in channel_availability_keys:
         if channel_availability in metadata.keys():
             break

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -120,8 +120,14 @@ def parse_metadata(metadata: dict) -> dict:
     else:
         num_planes = 1
         frames_per_slice = 1
-    active_channels = parse_matlab_vector(metadata["SI.hChannels.channelsActive"])
-    channel_indices = np.array(active_channels) - 1  # Account for MATLAB indexing
+
+    possible_channel_names = ["SI.hChannels.channelSave", "SI.hChannels.channelsave", "SI.hChannels.channelsActive"]
+    for key in possible_channel_names:
+        if key in metadata.keys():
+            break
+
+    saved_channels = parse_matlab_vector(metadata[key])
+    channel_indices = np.array(saved_channels) - 1  # Account for MATLAB indexing
     channel_names = np.array(metadata["SI.hChannels.channelName"].split("'")[1::2])
     channel_names = channel_names[channel_indices].tolist()
     num_channels = len(channel_names)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -121,13 +121,13 @@ def parse_metadata(metadata: dict) -> dict:
         num_planes = 1
         frames_per_slice = 1
 
-    possible_channel_names = ["SI.hChannels.channelSave", "SI.hChannels.channelsave", "SI.hChannels.channelsActive"]
-    for key in possible_channel_names:
-        if key in metadata.keys():
+    channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsave", "SI.hChannels.channelsActive"]
+    for channel_availability in channel_availability_keys:
+        if channel_availability in metadata.keys():
             break
 
-    saved_channels = parse_matlab_vector(metadata[key])
-    channel_indices = np.array(saved_channels) - 1  # Account for MATLAB indexing
+    available_channels = parse_matlab_vector(metadata[channel_availability])
+    channel_indices = np.array(available_channels) - 1  # Account for MATLAB indexing
     channel_names = np.array(metadata["SI.hChannels.channelName"].split("'")[1::2])
     channel_names = channel_names[channel_indices].tolist()
     num_channels = len(channel_names)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -67,7 +67,19 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
                 parsed_metadata=parsed_metadata,
             )
             imaging_extractors.append(imaging_extractor)
+
+        self._num_planes = imaging_extractors[0].get_num_planes()
         super().__init__(imaging_extractors=imaging_extractors)
+
+    def get_num_planes(self) -> int:
+        """Get the number of depth planes.
+
+        Returns
+        -------
+        _num_planes: int
+            The number of depth planes.
+        """
+        return self._num_planes
 
 
 class ScanImageTiffSinglePlaneMultiFileImagingExtractor(MultiImagingExtractor):


### PR DESCRIPTION
1. Updated channel detection logic in ScanImage TIFF processing:
  - Changed from using `SI.hChannels.channelsActive` to `SI.hChannels.channelSave` for determining saved channels. Kept the old logic for backup when the former key is not available.
  - Per Kim Lab: 
    > Actually, whether the channels are active or not doesn't matter to the experiment. When i do 1 channel imaging, I usually leave both channels on, but the shutter on the 2nd channel is not on so no laser is coming through and no images from channel 2 will be saved. (My other labmates sometimes like to leave the 2nd channel on, sometimes turn it off.)

2. Added missing `get_num_planes` method to `ScanImageTiffMultiPlaneMultiFileImagingExtractor` class.