### PR TITLE
Fix `ScanImage` sampling rate for volumetric extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-
+* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#401](https://github.com/catalystneuro/roiextractors/pull/401)
 ### Deprecations
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # v0.5.12 (Upcoming)
 
 ### Features
-* New `read_scanimage_metadata` for reading already parsed scanimage metadata.
+* New `read_scanimage_metadata` for reading scanimage metadata from a file directly as a python dict [#405](https://github.com/catalystneuro/roiextractors/pull/401)
 
 ### Fixes
 * Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#401](https://github.com/catalystneuro/roiextractors/pull/401)
-* Fixes the sampling rate for volumetric scanimage extractors
+* Fixes the sampling rate for volumetric `ScanImage` [#405](https://github.com/catalystneuro/roiextractors/pull/401)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # v0.5.12 (Upcoming)
 
 ### Features
+* New `read_scanimage_metadata` for reading already parsed scanimage metadata.
 
 ### Fixes
 * Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#401](https://github.com/catalystneuro/roiextractors/pull/401)
+* Fixes the sampling rate for volumetric scanimage extractors
+
 ### Deprecations
 
 ### Improvements

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -163,6 +163,7 @@ def read_scanimage_metadata(file_path: PathType) -> dict:
             break
 
     available_channels = non_varying_frame_metadata[channel_availability]
+    available_channels = [available_channels] if not isinstance(available_channels, list) else available_channels
     channel_indices = np.array(available_channels) - 1  # Account for MATLAB indexing
     channel_names = non_varying_frame_metadata["SI.hChannels.channelName"]
     channel_names_available = [channel_names[i] for i in channel_indices]

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -120,8 +120,16 @@ def parse_metadata(metadata: dict) -> dict:
     else:
         num_planes = 1
         frames_per_slice = 1
-    active_channels = parse_matlab_vector(metadata["SI.hChannels.channelsActive"])
-    channel_indices = np.array(active_channels) - 1  # Account for MATLAB indexing
+
+    # `channelSave` indicates whether the channel is saved. Note that a channel might not be saved even if it is active.
+    # We check `channelSave` first but keep the `channelsActive` check for backward compatibility.
+    channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsActive"]
+    for channel_availability in channel_availability_keys:
+        if channel_availability in metadata.keys():
+            break
+
+    available_channels = parse_matlab_vector(metadata[channel_availability])
+    channel_indices = np.array(available_channels) - 1  # Account for MATLAB indexing
     channel_names = np.array(metadata["SI.hChannels.channelName"].split("'")[1::2])
     channel_names = channel_names[channel_indices].tolist()
     num_channels = len(channel_names)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiff_utils.py
@@ -86,6 +86,110 @@ def parse_matlab_vector(matlab_vector: str) -> list:
     return vector
 
 
+def read_scanimage_metadata(file_path: PathType) -> dict:
+    """
+    Read and parse metadata from a ScanImage TIFF file.
+
+    This function extracts both the non-varying frame metadata and ROI group metadata
+    (if available) from a ScanImage TIFF file and processes them to extract key imaging parameters.
+
+    The function returns a python dictionary with fields already parsed to python objects (in opposition to a string)
+
+    Parameters
+    ----------
+    file_path : PathType
+        Path to the ScanImage TIFF file.
+
+    Returns
+    -------
+    metadata_dict : dict
+        Dictionary containing three nested dictionaries:
+        - scan_image_non_varying_frame_metadata: Raw non-varying frame metadata
+        - scan_image_roi_group_metadata: Raw ROI group metadata (if present)
+        - roiextractors_parsed_metadata: Parsed metadata with standardized keys:
+            - sampling_frequency: Frame or volume scan rate in Hz
+            - num_channels: Number of available imaging channels
+            - num_planes: Number of imaging planes (slices)
+            - frames_per_slice: Number of frames per Z slice
+            - channel_names: List of available channel names
+            - roi_metadata: ROI definitions (if present)
+
+    Notes
+    -----
+    The ScanImage TIFF format includes:
+    1. TIFF Header Section: Defines byte order and offsets
+    2. ScanImage Static Metadata Section: Contains metadata applicable to all frames
+        - Non-Varying Frame Data: System configuration for all frames
+        - ROI Group Data: Defined regions of interest (if available)
+    3. Frame Sections: One per image frame, containing:
+        - IFD Header: Image File Directory with tags and values
+        - Frame-specific data: Timestamps and other frame metadata
+        - Image data: The actual image pixels
+
+    The function uses the tifffile module's read_scanimage_metadata function to extract
+    the raw metadata, then processes it to standardize key imaging parameters.
+    """
+    from tifffile import read_scanimage_metadata
+
+    with open(file_path, "rb") as fh:
+        all_metadata = read_scanimage_metadata(fh)
+        non_varying_frame_metadata = all_metadata[0]
+        roi_group_metadata = all_metadata[1]
+
+    if non_varying_frame_metadata["SI.hStackManager.enable"]:
+        num_slices = non_varying_frame_metadata["SI.hStackManager.numSlices"]
+
+        flyback_frames = (
+            non_varying_frame_metadata["SI.hStackManager.numFramesPerVolumeWithFlyback"]
+            - non_varying_frame_metadata["SI.hStackManager.numFramesPerVolume"]
+        )
+        # num_planes = num_slices + flyback_frames   # TODO: discuss on issue, leave the current behavior now
+        num_planes = num_slices
+        frames_per_slice = non_varying_frame_metadata["SI.hStackManager.framesPerSlice"]
+    else:
+        num_planes = 1
+        frames_per_slice = 1
+
+    if num_planes == 1:
+        sampling_frequency = non_varying_frame_metadata["SI.hRoiManager.scanFrameRate"]
+    else:
+        sampling_frequency = non_varying_frame_metadata["SI.hRoiManager.scanVolumeRate"]
+
+    # `channelSave` indicates whether the channel is saved. Note that a channel might not be saved even if it is active.
+    # We check `channelSave` first but keep the `channelsActive` check for backward compatibility.
+    channel_availability_keys = ["SI.hChannels.channelSave", "SI.hChannels.channelsActive"]
+    for channel_availability in channel_availability_keys:
+        if channel_availability in non_varying_frame_metadata.keys():
+            break
+
+    available_channels = non_varying_frame_metadata[channel_availability]
+    channel_indices = np.array(available_channels) - 1  # Account for MATLAB indexing
+    channel_names = non_varying_frame_metadata["SI.hChannels.channelName"]
+    channel_names_available = [channel_names[i] for i in channel_indices]
+    num_channels = len(channel_names_available)
+    if roi_group_metadata:
+        roi_metadata = roi_group_metadata["RoiGroups"]
+    else:
+        roi_metadata = None
+
+    metadata_parsed = dict(
+        sampling_frequency=sampling_frequency,
+        num_channels=num_channels,
+        num_planes=num_planes,
+        frames_per_slice=frames_per_slice,
+        channel_names=channel_names_available,
+        roi_metadata=roi_metadata,
+    )
+
+    metadata_dict = dict(
+        scan_image_non_varying_frame_metadata=non_varying_frame_metadata,
+        scan_image_roi_group_metadata=roi_group_metadata,
+        roiextractors_parsed_metadata=metadata_parsed,
+    )
+
+    return metadata_dict
+
+
 def parse_metadata(metadata: dict) -> dict:
     """Parse metadata dictionary to extract relevant information and store it standard keys for ImagingExtractors.
 

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -20,6 +20,7 @@ from .scanimagetiff_utils import (
     parse_metadata,
     extract_timestamps_from_file,
     _get_scanimage_reader,
+    read_scanimage_metadata,
 )
 
 
@@ -53,9 +54,11 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
         file_paths = natsorted(self.folder_path.glob(file_pattern))
         if len(file_paths) == 0:
             raise ValueError(f"No files found in folder with pattern: {file_pattern}")
+
+        self.metadata = read_scanimage_metadata(file_paths[0])
         if not extract_all_metadata:
-            metadata = extract_extra_metadata(file_paths[0])
-            parsed_metadata = parse_metadata(metadata)
+            metadata = self.metadata
+            parsed_metadata = self.metadata["roiextractors_parsed_metadata"]
         else:
             metadata, parsed_metadata = None, None
         imaging_extractors = []
@@ -70,6 +73,9 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
 
         self._num_planes = imaging_extractors[0].get_num_planes()
         super().__init__(imaging_extractors=imaging_extractors)
+
+    def get_sampling_frequency(self) -> float:
+        return self._imaging_extractors[0].get_sampling_frequency()
 
     def get_num_planes(self) -> int:
         """Get the number of depth planes.
@@ -120,8 +126,8 @@ class ScanImageTiffSinglePlaneMultiFileImagingExtractor(MultiImagingExtractor):
         if len(file_paths) == 0:
             raise ValueError(f"No files found in folder with pattern: {file_pattern}")
         if not extract_all_metadata:
-            metadata = extract_extra_metadata(file_paths[0])
-            parsed_metadata = parse_metadata(metadata)
+            metadata = read_scanimage_metadata(file_paths[0])
+            parsed_metadata = metadata["roiextractors_parsed_metadata"]
         else:
             metadata, parsed_metadata = None, None
         imaging_extractors = []
@@ -171,8 +177,8 @@ class ScanImageTiffMultiPlaneImagingExtractor(VolumetricImagingExtractor):
         """
         self.file_path = Path(file_path)
         if metadata is None:
-            self.metadata = extract_extra_metadata(file_path)
-            self.parsed_metadata = parse_metadata(self.metadata)
+            self.metadata = read_scanimage_metadata(file_path)
+            self.parsed_metadata = self.metadata["roiextractors_parsed_metadata"]
         else:
             self.metadata = metadata
             assert parsed_metadata is not None, "If metadata is provided, parsed_metadata must also be provided."
@@ -287,8 +293,8 @@ class ScanImageTiffSinglePlaneImagingExtractor(ImagingExtractor):
         """
         self.file_path = Path(file_path)
         if metadata is None:
-            self.metadata = extract_extra_metadata(file_path)
-            self.parsed_metadata = parse_metadata(self.metadata)
+            self.metadata = read_scanimage_metadata(file_path)
+            self.parsed_metadata = self.metadata["roiextractors_parsed_metadata"]
         else:
             self.metadata = metadata
             assert parsed_metadata is not None, "If metadata is provided, parsed_metadata must also be provided."

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -67,7 +67,19 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
                 parsed_metadata=parsed_metadata,
             )
             imaging_extractors.append(imaging_extractor)
+
+        self._num_planes = imaging_extractors[0].get_num_planes()
         super().__init__(imaging_extractors=imaging_extractors)
+
+    def get_num_planes(self) -> int:
+        """Get the number of depth planes.
+
+        Returns
+        -------
+        _num_planes: int
+            The number of depth planes.
+        """
+        return self._num_planes
 
 
 class ScanImageTiffSinglePlaneMultiFileImagingExtractor(MultiImagingExtractor):

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -74,9 +74,6 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
         self._num_planes = imaging_extractors[0].get_num_planes()
         super().__init__(imaging_extractors=imaging_extractors)
 
-    def get_sampling_frequency(self) -> float:
-        return self._imaging_extractors[0].get_sampling_frequency()
-
     def get_num_planes(self) -> int:
         """Get the number of depth planes.
 

--- a/tests/test_scanimagetiffimagingextractor.py
+++ b/tests/test_scanimagetiffimagingextractor.py
@@ -31,7 +31,7 @@ def file_path():
 @pytest.fixture(scope="module")
 def expected_properties():
     return dict(
-        sampling_frequency=29.1248,
+        sampling_frequency=7.28119,
         num_channels=2,
         num_planes=2,
         frames_per_slice=2,


### PR DESCRIPTION
Currently, `ScanImage` retrieves the same sampling rate for both volumetric and non-volumetric data. This is wrong and the sampling rate should be slower for volumetric data. I am fixing this here.

Additionally, I am extracting the metadata using `read_scanimage_metadata` from the corresponding `tifffile` library. This approach has several advantages:

- I spoke with Lawrence from the ScanImage team today, and he indicated that the `scanimage-tiff-reader` library should be considered unmaintained. We've already encountered problems with ARM Macs, so transitioning to this method is a step in the right direction.
- The `read_scanimage_metadata` function directly returns metadata parsed into Python objects. This means we no longer need to maintain our own parsing logic like parsing matlab vector strings. 
- It's significantly faster—approximately 40 times, based on my preliminary profiling.



![image](https://github.com/user-attachments/assets/48a697f7-7867-4461-b8fc-ee5c86273835)
