### PR TITLE
Remove `installed` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * The `get_image_size()` method is deprecated and will be removed in or after September 2025. Use `get_image_shape()` instead for consistent behavior across all extractors. [#409](https://github.com/catalystneuro/roiextractors/pull/409)
 
 ### Improvements
-
+* Removed unused installed attribute [#410](https://github.com/catalystneuro/roiextractors/pull/410)
 
 # v0.5.11 (March 5th, 2025)
 

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -67,8 +67,6 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         offset : int, optional
             The offset in bytes. Usually corresponds to the number of bytes occupied by the header. 0 by default.
         """
-        self.installed = True
-
         self.file_path = Path(file_path)
         self.video_structure = video_structure
         self._sampling_frequency = float(sampling_frequency)

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -24,7 +24,6 @@ class NumpyImagingExtractor(ImagingExtractor):
     """An ImagingExtractor specified by timeseries .npy file, sampling frequency, and channel names."""
 
     extractor_name = "NumpyImagingExtractor"
-    installed = True
     is_writable = True
     installation_mesg = ""  # error message when not installed
 
@@ -234,7 +233,6 @@ class NumpySegmentationExtractor(SegmentationExtractor):
     """
 
     extractor_name = "NumpySegmentationExtractor"
-    installed = True  # check at class level if installed or not
     is_writable = True
     mode = "file"
     installation_mesg = ""  # error message when not installed

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -302,7 +302,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
     """An segmentation extractor for NWB files."""
 
     extractor_name = "NwbSegmentationExtractor"
-    installed = True  # check at class level if installed or not
     is_writable = False
     mode = "file"
     installation_mesg = ""  # error message when not installed

--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -22,7 +22,6 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
     """A segmentation extractor for Suite2p."""
 
     extractor_name = "Suite2pSegmentationExtractor"
-    installed = True  # check at class level if installed or not
     is_writable = False
     mode = "folder"
     installation_mesg = ""  # error message when not installed

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -390,7 +390,6 @@ class FrameSliceImagingExtractor(ImagingExtractor):
     """
 
     extractor_name = "FrameSliceImagingExtractor"
-    installed = True
     is_writable = True
     installation_mesg = ""
 

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -20,7 +20,6 @@ class MultiImagingExtractor(ImagingExtractor):
     """Class to combine multiple ImagingExtractor objects by frames."""
 
     extractor_name = "MultiImagingExtractor"
-    installed = True
     installation_mesg = ""
 
     def __init__(self, imaging_extractors: List[ImagingExtractor]):

--- a/src/roiextractors/multisegmentationextractor.py
+++ b/src/roiextractors/multisegmentationextractor.py
@@ -59,7 +59,6 @@ class MultiSegmentationExtractor(SegmentationExtractor):
     """Class is used to concatenate multi-plane recordings from the same device and session of experiment."""
 
     extractor_name = "MultiSegmentationExtractor"
-    installed = True  # check at class level if installed or not
     is_writable = False
     mode = "file"
     installation_mesg = ""  # error message when not installed

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -12,7 +12,6 @@ class VolumetricImagingExtractor(ImagingExtractor):
     """Class to combine multiple ImagingExtractor objects by depth plane."""
 
     extractor_name = "VolumetricImaging"
-    installed = True
     installatiuon_mesage = ""
 
     def __init__(self, imaging_extractors: List[ImagingExtractor]):
@@ -225,7 +224,6 @@ class DepthSliceVolumetricImagingExtractor(VolumetricImagingExtractor):
     """
 
     extractor_name = "DepthSliceVolumetricImagingExtractor"
-    installed = True
     is_writable = True
     installation_mesg = ""
 


### PR DESCRIPTION
I think this was left from the SpikeExtractors time and it does not have any use whatsoever currently.