### PR TITLE
Fix imaging extractor string representation for volumetric imaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 
 ### Fixes
-* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [#401](https://github.com/catalystneuro/roiextractors/pull/401)
+* Use `SI.hChannels.channelSave` or `SI.hChannels.channelsave` to determine number of channels for ScanImage extractors when available [PR #401](https://github.com/catalystneuro/roiextractors/pull/401)
 * Fixes the sampling rate for volumetric `ScanImage` [#405](https://github.com/catalystneuro/roiextractors/pull/401)
 * Fixed `get_series` method in `MemmapImagingExtractor` to preserve channel dimension [#416](https://github.com/catalystneuro/roiextractors/pull/416)
+* Fix memory estimation for volumetric imaging extractors in their `_repr_` [PR #422](https://github.com/catalystneuro/roiextractors/pull/433)
 
 ### Deprecations
 * Deprecated `write_imaging` and `write_segmentation` methods: [#403](https://github.com/catalystneuro/roiextractors/pull/403)

--- a/src/roiextractors/core_utils.py
+++ b/src/roiextractors/core_utils.py
@@ -1,3 +1,6 @@
+"""Class for some core utilities."""
+
+
 def _convert_seconds_to_str(seconds):
     """Convert seconds to a human-readable string."""
     if seconds < 60:

--- a/src/roiextractors/core_utils.py
+++ b/src/roiextractors/core_utils.py
@@ -1,0 +1,31 @@
+def _convert_seconds_to_str(seconds):
+    """Convert seconds to a human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f}min"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.1f}h"
+
+
+def _convert_bytes_to_str(size_in_bytes):
+    """
+    Convert bytes to a human-readable string.
+
+    Convert bytes to a human-readable string using IEC binary prefixes (KiB, MiB, GiB).
+    Note that RAM memory is typically measured in IEC binary prefixes  while disk storage is typically
+    measured in SI binary prefixes.
+    """
+    if size_in_bytes < 1024:
+        return f"{size_in_bytes}B"
+    elif size_in_bytes < 1024 * 1024:
+        size_kb = size_in_bytes / 1024
+        return f"{size_kb:.1f}KiB"
+    elif size_in_bytes < 1024 * 1024 * 1024:
+        size_mb = size_in_bytes / (1024 * 1024)
+        return f"{size_mb:.1f}MiB"
+    else:
+        size_gb = size_in_bytes / (1024 * 1024 * 1024)
+        return f"{size_gb:.1f}GiB"

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -112,8 +112,7 @@ class ImagingExtractor(ABC):
 
         Notes
         -----
-        This method is equivalent to get_image_shape() and is provided for consistency
-        with the naming convention used in volumetric extractors.
+        This method is equivalent to get_image_shape()
         """
         return self.get_image_shape()
 
@@ -121,8 +120,14 @@ class ImagingExtractor(ABC):
         """
         Get the shape of a single sample elements from the series.
 
-        If the series is volumetric, the shape is the shape of the volume, otherwise
-        thsi returns the shape of a single frame/image.
+        If the series is volumetric, the shape is the shape of the volume and otherwise
+        returns the shape of a single frame/image.
+
+        Returns
+        -------
+        sample_shape: tuple
+            Shape of a single sample from the time series (num_rows, num_columns, num_planes)
+            if volumetric (num_rows, num_columns) otherwise
         """
         if self.is_volumetric:
             return self.get_volume_shape()

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -116,7 +116,7 @@ class ImagingExtractor(ABC):
         """
         return self.get_image_shape()
 
-    def get_sample_shape(self) -> Tuple[int, int] | Tuple[int, int, int]:
+    def get_sample_shape(self) -> Union[Tuple[int, int], Tuple[int, int, int]]:
         """
         Get the shape of a single sample elements from the series.
 

--- a/tests/test_scanimage_extractor.py
+++ b/tests/test_scanimage_extractor.py
@@ -327,7 +327,7 @@ class TestScanImageExtractorVolumetricMultiSample:
 
                 # Calculate the corresponding index in the tiff data
                 # Each sample has 2 frames per slice, and we're using slice_sample=0
-                tiff_frame_index = sample_index * 2 + frame_index
+                tiff_frame_index = sample_index * frames_per_slice + frame_index
                 frame_tiff = data[tiff_frame_index, tiff_slice_sample_index, tiff_channel_index, ...]
 
                 np.testing.assert_array_equal(
@@ -347,7 +347,7 @@ class TestScanImageExtractorVolumetricMultiSample:
 
                 # Calculate the corresponding index in the tiff data
                 # Each sample has 2 frames per slice, and we're using slice_sample=1
-                tiff_frame_index = sample_index * 2 + frame_index
+                tiff_frame_index = sample_index * frames_per_slice + frame_index
                 frame_tiff = data[tiff_frame_index, tiff_slice_sample_index, tiff_channel_index, ...]
 
                 np.testing.assert_array_equal(


### PR DESCRIPTION
This brings some improvements:

1) The current representation is using image_size  which is deprecated and also leads to wrong estimates for volumetric data. This new PR uses a the shape of the sample so the memory estimation is correct.
2) Introduces the `get_sample_shape` which returns `get_image_shape` for planar extractor and `get_volume_shape` for volumetric extractors. Following on #406
3) It moves the methods to format times and memory to their own module to keep the base class clean.