### PR TITLE
Add string as paths support for `ScanImageImagingExtractor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Added support for multiple samples per slice to `ScanImageIMagingExtractor` [PR # 417](https://github.com/catalystneuro/roiextractors/pull/417)
 * Added support for flyback frames to `ScanImageImagingExtractor` [PR #419](https://github.com/catalystneuro/roiextractors/pull/419)
 * Add `plane_index` to `ScanImageImagingExtractor` to obtain a planar extractor across a plane [PR #424](https://github.com/catalystneuro/roiextractors/pull/424)
-* Add paths as string support to `ScanImageImagingExtractor` [PR #420]()
-* Add informative error for older ScanImage files [PR #421]()
+* Add paths as string support to `ScanImageImagingExtractor` [PR #427](https://github.com/catalystneuro/roiextractors/pull/427)
+* Add informative error for old ScanImage files with `ScanImageImagingExtractor` [PR #427](https://github.com/catalystneuro/roiextractors/pull/427)
 
 ### Fixes
 * Fixed `get_series` method in `MemmapImagingExtractor` to preserve channel dimension [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Added support for multiple samples per slice to `ScanImageIMagingExtractor` [PR # 417](https://github.com/catalystneuro/roiextractors/pull/417)
 * Added support for flyback frames to `ScanImageImagingExtractor` [PR #419](https://github.com/catalystneuro/roiextractors/pull/419)
 * Add `plane_index` to `ScanImageImagingExtractor` to obtain a planar extractor across a plane [PR #424](https://github.com/catalystneuro/roiextractors/pull/424)
+* Add paths as string support to `ScanImageImagingExtractor` [PR #420]()
+* Add informative error for older ScanImage files [PR #421]()
 
 ### Fixes
 * Fixed `get_series` method in `MemmapImagingExtractor` to preserve channel dimension [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -87,6 +87,7 @@ class ScanImageImagingExtractor(ImagingExtractor):
         super().__init__()
         self.file_path = file_paths[0] if file_paths is not None else file_path
         assert self.file_path is not None, "file_path or file_paths must be provided"
+        self.file_path = Path(self.file_path)
 
         # Validate file suffix
         valid_suffixes = [".tiff", ".tif", ".TIFF", ".TIF"]
@@ -97,11 +98,19 @@ class ScanImageImagingExtractor(ImagingExtractor):
                 f"The {self.extractor_name} Extractor may not be appropriate for the file."
             )
 
-        # Open the
+        # Open the TIFF file
         tifffile = get_package(package_name="tifffile")
         tiff_reader = tifffile.TiffReader(self.file_path)
 
         self._general_metadata = tiff_reader.scanimage_metadata
+        non_valid_metadata = self._general_metadata is None or len(self._general_metadata) == 0
+        if non_valid_metadata:
+            error_msg = (
+                f"Invalid metadata for file with name {file_path.name}. \n"
+                "The metadata is either None or empty which probably indictes that the tiff file "
+                "Is not a ScanImage file or it could be an older version."
+            )
+            raise ValueError("Invalid metadata: The metadata is either None or empty.")
         self._metadata = self._general_metadata["FrameData"]
 
         self._num_rows, self._num_columns = tiff_reader.pages[0].shape

--- a/tests/test_scanimage_extractor.py
+++ b/tests/test_scanimage_extractor.py
@@ -38,7 +38,7 @@ class TestScanImageExtractor:
         # This is frame per slice 24 and should fail
         file_path = SCANIMAGE_PATH / "scanimage_20220801_single.tif"
 
-        extractor = ScanImageImagingExtractor(file_path=file_path)
+        extractor = ScanImageImagingExtractor(file_path=str(file_path))
 
         assert extractor.is_volumetric == False
         assert extractor.get_num_samples() == 3

--- a/tests/test_scanimage_extractor.py
+++ b/tests/test_scanimage_extractor.py
@@ -13,6 +13,14 @@ from .setup_paths import OPHYS_DATA_PATH
 SCANIMAGE_PATH = OPHYS_DATA_PATH / "imaging_datasets" / "ScanImage"
 
 
+def test_old_scan_image_version():
+    """Test that an error informative error is raised when using an old ScanImage version."""
+    file_path = SCANIMAGE_PATH / "sample_scanimage_version_3_8.tiff"
+
+    with pytest.raises(ValueError):
+        ScanImageImagingExtractor(file_path=file_path)
+
+
 class TestScanImageExtractor:
     """Test the ScanImage extractor classes with various ScanImage files."""
 


### PR DESCRIPTION
As in the title, this enables reading of paths when they are input as strings instead of paths.

I am also adding an informative error when the metadata could not be read. 