### PR TITLE
More sample based terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added support for multiple samples per slice to `ScanImageIMagingExtractor` [PR # 417](https://github.com/catalystneuro/roiextractors/pull/417)
 * Added support for flyback frames to `ScanImageImagingExtractor` [PR #419](https://github.com/catalystneuro/roiextractors/pull/419)
 * Add `plane_index` to `ScanImageImagingExtractor` to obtain a planar extractor across a plane [PR #424](https://github.com/catalystneuro/roiextractors/pull/424)
-* Add testing to timestamp extraction on `ScanImageImagingExtractor` [PR #426](https://github.com/catalystneuro/
+* Add testing to timestamp extraction on `ScanImageImagingExtractor` [PR #426](https://github.com/catalystneuro/roiextractors/pull/426)
 * Add paths as string support to `ScanImageImagingExtractor` [PR #427](https://github.com/catalystneuro/roiextractors/pull/427)
 * Add informative error for old ScanImage files with `ScanImageImagingExtractor` [PR #427](https://github.com/catalystneuro/roiextractors/pull/427)
 * Add the option to read interleaved data in `ScanImageImagingExtractor` [PR #428](https://github.com/catalystneuro/roiextractors/pull/428)
@@ -18,16 +18,14 @@
 ### Deprecations
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
-* The `time_to_frame()` method is deprecated and will be removed in or after October 2025. Use `time_to_sample_indices()` instead for consistent terminology between planar and volumetric data.
-* The `frame_to_time()` method is deprecated and will be removed in or after October 2025. Use `sample_indices_to_time()` instead for consistent terminology between planar and volumetric data.
-* The `frame_slice()` method is deprecated and will be removed in or after October 2025. Use `slice_samples()` instead for consistent terminology between planar and volumetric data.
+* The `time_to_frame()` method is deprecated and will be removed in or after October 2025. Use `time_to_sample_indices()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
+* The `frame_to_time()` method is deprecated and will be removed in or after October 2025. Use `sample_indices_to_time()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
+* The `frame_slice()` method is deprecated and will be removed in or after October 2025. Use `slice_samples()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
 * The `FrameSliceImagingExtractor` class is deprecated and will be removed in or after October 2025. Use `SliceSamplesImagingExtractor` instead for consistent terminology between planar and volumetric data.
+[PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)
-
-
-
 
 # v0.5.12 (April 18th, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,16 @@
 ### Deprecations
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
+* The `time_to_frame()` method is deprecated and will be removed in or after October 2025. Use `time_to_sample_indices()` instead for consistent terminology between planar and volumetric data.
+* The `frame_to_time()` method is deprecated and will be removed in or after October 2025. Use `sample_indices_to_time()` instead for consistent terminology between planar and volumetric data.
+* The `frame_slice()` method is deprecated and will be removed in or after October 2025. Use `slice_samples()` instead for consistent terminology between planar and volumetric data.
+* The `FrameSliceImagingExtractor` class is deprecated and will be removed in or after October 2025. Use `SliceSamplesImagingExtractor` instead for consistent terminology between planar and volumetric data.
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)
+
+
+
 
 # v0.5.12 (April 18th, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * The `time_to_frame()` method is deprecated and will be removed in or after October 2025. Use `time_to_sample_indices()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
 * The `frame_to_time()` method is deprecated and will be removed in or after October 2025. Use `sample_indices_to_time()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
 * The `frame_slice()` method is deprecated and will be removed in or after October 2025. Use `slice_samples()` instead for consistent terminology between planar and volumetric data. [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
-* The `FrameSliceImagingExtractor` class is deprecated and will be removed in or after October 2025. Use `SliceSamplesImagingExtractor` instead for consistent terminology between planar and volumetric data.
+* The `FrameSliceImagingExtractor` class is deprecated and will be removed in or after October 2025. Use `SampleSlicedImagingExtractor` instead for consistent terminology between planar and volumetric data.
 [PR #430](https://github.com/catalystneuro/roiextractors/pull/430)
 
 ### Improvements

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -515,10 +515,10 @@ class ImagingExtractor(ABC):
 
         Returns
         -------
-        imaging: SliceSamplesImagingExtractor
+        imaging: SampleSlicedImagingExtractor
             The sliced ImagingExtractor object.
         """
-        return SliceSamplesImagingExtractor(parent_imaging=self, start_sample=start_sample, end_sample=end_sample)
+        return SampleSlicedImagingExtractor(parent_imaging=self, start_sample=start_sample, end_sample=end_sample)
 
     def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         """Return a new ImagingExtractor ranging from the start_frame to the end_frame.
@@ -548,15 +548,13 @@ class ImagingExtractor(ABC):
         return self.slice_samples(start_sample=start_frame, end_sample=end_frame)
 
 
-class SliceSamplesImagingExtractor(ImagingExtractor):
+class SampleSlicedImagingExtractor(ImagingExtractor):
     """Class to get a lazy sample slice.
 
     Do not use this class directly but use `.slice_samples(...)` on an ImagingExtractor object.
     """
 
-    extractor_name = "SliceSamplesImagingExtractor"
-    is_writable = True
-    installation_mesg = ""
+    extractor_name = "SampleSlicedImagingExtractor"
 
     def __init__(
         self, parent_imaging: ImagingExtractor, start_sample: Optional[int] = None, end_sample: Optional[int] = None
@@ -721,7 +719,7 @@ class SliceSamplesImagingExtractor(ImagingExtractor):
         return self._parent_imaging.get_num_planes()
 
 
-class FrameSliceImagingExtractor(SliceSamplesImagingExtractor):
+class FrameSliceImagingExtractor(SampleSlicedImagingExtractor):
     """Class to get a lazy frame slice.
 
     Do not use this class directly but use `.frame_slice(...)` on an ImagingExtractor object.
@@ -729,7 +727,7 @@ class FrameSliceImagingExtractor(SliceSamplesImagingExtractor):
     Deprecated
     ----------
     This class will be removed in or after October 2025.
-    Use SliceSamplesImagingExtractor instead.
+    Use SampleSlicedImagingExtractor instead.
     """
 
     extractor_name = "FrameSliceImagingExtractor"
@@ -756,11 +754,11 @@ class FrameSliceImagingExtractor(SliceSamplesImagingExtractor):
         Deprecated
         ----------
         This class will be removed in or after October 2025.
-        Use SliceSamplesImagingExtractor instead.
+        Use SampleSlicedImagingExtractor instead.
         """
         warnings.warn(
             "FrameSliceImagingExtractor is deprecated and will be removed in or after October 2025. "
-            "Use SliceSamplesImagingExtractor instead.",
+            "Use SampleSlicedImagingExtractor instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -367,6 +367,25 @@ class ImagingExtractor(ABC):
         series = self.get_series(start_sample=frame_idxs[0], end_sample=frame_idxs[-1] + 1)
         return series[relative_indices]
 
+    def sample_indices_to_time(self, sample_indices: Union[FloatType, np.ndarray]) -> Union[FloatType, np.ndarray]:
+        """Convert user-inputted sample indices to times with units of seconds.
+
+        Parameters
+        ----------
+        sample_indices: int or array-like
+            The sample indices to be converted to times.
+
+        Returns
+        -------
+        times: float or array-like
+            The corresponding times in seconds.
+        """
+        # Default implementation
+        if self._times is None:
+            return sample_indices / self.get_sampling_frequency()
+        else:
+            return self._times[sample_indices]
+
     def frame_to_time(self, frames: Union[FloatType, np.ndarray]) -> Union[FloatType, np.ndarray]:
         """Convert user-inputted frame indices to times with units of seconds.
 
@@ -379,12 +398,38 @@ class ImagingExtractor(ABC):
         -------
         times: float or array-like
             The corresponding times in seconds.
+
+        Deprecated
+        ----------
+        This method will be removed in or after October 2025.
+        Use sample_indices_to_time() instead.
+        """
+        warnings.warn(
+            "frame_to_time() is deprecated and will be removed in or after October 2025. "
+            "Use sample_indices_to_time() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.sample_indices_to_time(frames)
+
+    def time_to_sample_indices(self, times: Union[FloatType, ArrayType]) -> Union[FloatType, np.ndarray]:
+        """Convert user-inputted times (in seconds) to sample indices.
+
+        Parameters
+        ----------
+        times: float or array-like
+            The times (in seconds) to be converted to sample indices.
+
+        Returns
+        -------
+        sample_indices: float or array-like
+            The corresponding sample indices.
         """
         # Default implementation
         if self._times is None:
-            return frames / self.get_sampling_frequency()
+            return np.round(times * self.get_sampling_frequency()).astype("int64")
         else:
-            return self._times[frames]
+            return np.searchsorted(self._times, times).astype("int64")
 
     def time_to_frame(self, times: Union[FloatType, ArrayType]) -> Union[FloatType, np.ndarray]:
         """Convert a user-inputted times (in seconds) to a frame indices.
@@ -398,12 +443,19 @@ class ImagingExtractor(ABC):
         -------
         frames: float or array-like
             The corresponding frame indices.
+
+        Deprecated
+        ----------
+        This method will be removed in or after October 2025.
+        Use time_to_sample_indices() instead.
         """
-        # Default implementation
-        if self._times is None:
-            return np.round(times * self.get_sampling_frequency()).astype("int64")
-        else:
-            return np.searchsorted(self._times, times).astype("int64")
+        warnings.warn(
+            "time_to_frame() is deprecated and will be removed in or after October 2025. "
+            "Use time_to_sample_indices() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.time_to_sample_indices(times)
 
     def set_times(self, times: ArrayType) -> None:
         """Set the recording times (in seconds) for each frame.
@@ -451,6 +503,23 @@ class ImagingExtractor(ABC):
         if extractor._times is not None:
             self.set_times(deepcopy(extractor._times))
 
+    def slice_samples(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None):
+        """Return a new ImagingExtractor ranging from the start_sample to the end_sample.
+
+        Parameters
+        ----------
+        start_sample: int, optional
+            Start sample index (inclusive).
+        end_sample: int, optional
+            End sample index (exclusive).
+
+        Returns
+        -------
+        imaging: SliceSamplesImagingExtractor
+            The sliced ImagingExtractor object.
+        """
+        return SliceSamplesImagingExtractor(parent_imaging=self, start_sample=start_sample, end_sample=end_sample)
+
     def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         """Return a new ImagingExtractor ranging from the start_frame to the end_frame.
 
@@ -465,19 +534,205 @@ class ImagingExtractor(ABC):
         -------
         imaging: FrameSliceImagingExtractor
             The sliced ImagingExtractor object.
+
+        Deprecated
+        ----------
+        This method will be removed in or after October 2025.
+        Use slice_samples() instead.
         """
-        return FrameSliceImagingExtractor(parent_imaging=self, start_frame=start_frame, end_frame=end_frame)
+        warnings.warn(
+            "frame_slice() is deprecated and will be removed in or after October 2025. " "Use slice_samples() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.slice_samples(start_sample=start_frame, end_sample=end_frame)
 
 
-class FrameSliceImagingExtractor(ImagingExtractor):
+class SliceSamplesImagingExtractor(ImagingExtractor):
+    """Class to get a lazy sample slice.
+
+    Do not use this class directly but use `.slice_samples(...)` on an ImagingExtractor object.
+    """
+
+    extractor_name = "SliceSamplesImagingExtractor"
+    is_writable = True
+    installation_mesg = ""
+
+    def __init__(
+        self, parent_imaging: ImagingExtractor, start_sample: Optional[int] = None, end_sample: Optional[int] = None
+    ):
+        """Initialize an ImagingExtractor whose samples subset the parent.
+
+        Subset is exclusive on the right bound, that is, the indexes of this ImagingExtractor range over
+        [0, ..., end_sample-start_sample-1], which is used to resolve the index mapping in `get_frames(frame_idxs=[...])`.
+
+        Parameters
+        ----------
+        parent_imaging : ImagingExtractor
+            The ImagingExtractor object to subset the samples of.
+        start_sample : int, optional
+            The left bound of the samples to subset.
+            The default is the start sample of the parent.
+        end_sample : int, optional
+            The right bound of the samples, exclusively, to subset.
+            The default is end sample of the parent.
+        """
+        self._parent_imaging = parent_imaging
+        self._start_frame = start_sample
+        self._end_frame = end_sample
+        self._num_samples = self._end_frame - self._start_frame
+
+        parent_size = self._parent_imaging.get_num_samples()
+        if start_sample is None:
+            start_sample = 0
+        else:
+            assert 0 <= start_sample < parent_size
+        if end_sample is None:
+            end_sample = parent_size
+        else:
+            assert 0 < end_sample <= parent_size
+        assert end_sample > start_sample, "'start_sample' must be smaller than 'end_sample'!"
+
+        super().__init__()
+        if getattr(self._parent_imaging, "_times") is not None:
+            self._times = self._parent_imaging._times[start_sample:end_sample]
+
+        # Inherit volumetric properties from parent
+        self.is_volumetric = self._parent_imaging.is_volumetric
+
+    def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> np.ndarray:
+        assert max(frame_idxs) < self._num_samples, "'frame_idxs' range beyond number of available frames!"
+        mapped_frame_idxs = np.array(frame_idxs) + self._start_frame
+        return self._parent_imaging.get_frames(frame_idxs=mapped_frame_idxs, channel=channel)
+
+    def get_series(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None) -> np.ndarray:
+        assert start_sample is None or start_sample >= 0, (
+            f"'start_sample' must be greater than or equal to zero! Received '{start_sample}'.\n"
+            "Negative slicing semantics are not supported."
+        )
+        start_sample_shifted = (start_sample or 0) + self._start_frame
+        end_sample_shifted = end_sample
+        if end_sample is not None:
+            end_sample_shifted = end_sample + self._start_frame
+        return self._parent_imaging.get_series(start_sample=start_sample_shifted, end_sample=end_sample_shifted)
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: Optional[int] = 0
+    ) -> np.ndarray:
+        warnings.warn(
+            "get_video() is deprecated and will be removed in or after September 2025. " "Use get_series() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if channel != 0:
+            warnings.warn(
+                "The 'channel' parameter in get_video() is deprecated and will be removed in August 2025.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self.get_series(start_sample=start_frame, end_sample=end_frame)
+
+    def get_image_shape(self) -> Tuple[int, int]:
+        """Get the shape of the video frame (num_rows, num_columns).
+
+        Returns
+        -------
+        image_shape: tuple
+            Shape of the video frame (num_rows, num_columns).
+        """
+        return self._parent_imaging.get_image_shape()
+
+    def get_image_size(self) -> Tuple[int, int]:
+        warnings.warn(
+            "get_image_size() is deprecated and will be removed in or after September 2025. "
+            "Use get_image_shape() instead for consistent behavior across all extractors.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return tuple(self._parent_imaging.get_image_size())
+
+    def get_num_samples(self) -> int:
+        return self._num_samples
+
+    def get_num_frames(self) -> int:
+        """Get the number of frames in the video.
+
+        Returns
+        -------
+        num_frames: int
+            Number of frames in the video.
+
+        Deprecated
+        ----------
+        This method will be removed in or after September 2025.
+        Use get_num_samples() instead.
+        """
+        warnings.warn(
+            "get_num_frames() is deprecated and will be removed in or after September 2025. "
+            "Use get_num_samples() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_num_samples()
+
+    def get_sampling_frequency(self) -> float:
+        return self._parent_imaging.get_sampling_frequency()
+
+    def get_channel_names(self) -> list:
+        return self._parent_imaging.get_channel_names()
+
+    def get_num_channels(self) -> int:
+        """Get the total number of active channels in the recording.
+
+        Returns
+        -------
+        num_channels: int
+            Integer count of number of channels.
+
+        Deprecated
+        ----------
+        This method will be removed in or after August 2025.
+        """
+        warnings.warn(
+            "get_num_channels() is deprecated and will be removed in or after August 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._parent_imaging.get_num_channels()
+
+    def get_num_planes(self) -> int:
+        """Get the number of depth planes.
+
+        Returns
+        -------
+        num_planes: int
+            The number of depth planes.
+
+        Raises
+        ------
+        NotImplementedError
+            If the parent extractor is not volumetric.
+        """
+        if not self.is_volumetric:
+            raise NotImplementedError(
+                "This extractor is not volumetric. "
+                "The get_num_planes method is only available for volumetric extractors."
+            )
+        return self._parent_imaging.get_num_planes()
+
+
+class FrameSliceImagingExtractor(SliceSamplesImagingExtractor):
     """Class to get a lazy frame slice.
 
     Do not use this class directly but use `.frame_slice(...)` on an ImagingExtractor object.
+
+    Deprecated
+    ----------
+    This class will be removed in or after October 2025.
+    Use SliceSamplesImagingExtractor instead.
     """
 
     extractor_name = "FrameSliceImagingExtractor"
-    is_writable = True
-    installation_mesg = ""
 
     def __init__(
         self, parent_imaging: ImagingExtractor, start_frame: Optional[int] = None, end_frame: Optional[int] = None
@@ -498,29 +753,18 @@ class FrameSliceImagingExtractor(ImagingExtractor):
             The right bound of the frames, exlcusively, to subset.
             The default is end frame of the parent.
 
+        Deprecated
+        ----------
+        This class will be removed in or after October 2025.
+        Use SliceSamplesImagingExtractor instead.
         """
-        self._parent_imaging = parent_imaging
-        self._start_frame = start_frame
-        self._end_frame = end_frame
-        self._num_samples = self._end_frame - self._start_frame
-
-        parent_size = self._parent_imaging.get_num_samples()
-        if start_frame is None:
-            start_frame = 0
-        else:
-            assert 0 <= start_frame < parent_size
-        if end_frame is None:
-            end_frame = parent_size
-        else:
-            assert 0 < end_frame <= parent_size
-        assert end_frame > start_frame, "'start_frame' must be smaller than 'end_frame'!"
-
-        super().__init__()
-        if getattr(self._parent_imaging, "_times") is not None:
-            self._times = self._parent_imaging._times[start_frame:end_frame]
-
-        # Inherit volumetric properties from parent
-        self.is_volumetric = self._parent_imaging.is_volumetric
+        warnings.warn(
+            "FrameSliceImagingExtractor is deprecated and will be removed in or after October 2025. "
+            "Use SliceSamplesImagingExtractor instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(parent_imaging=parent_imaging, start_sample=start_frame, end_sample=end_frame)
 
     def get_frames(self, frame_idxs: ArrayType, channel: Optional[int] = 0) -> np.ndarray:
         assert max(frame_idxs) < self._num_samples, "'frame_idxs' range beyond number of available frames!"

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -263,11 +263,26 @@ class VolumetricImagingExtractor(ImagingExtractor):
 
         return DepthSliceVolumetricImagingExtractor(parent_extractor=self, start_plane=start_plane, end_plane=end_plane)
 
-    def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
-        """Return a new VolumetricImagingExtractor with a subset of frames."""
+    def slice_samples(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None):
+        """Return a new VolumetricImagingExtractor with a subset of samples."""
         raise NotImplementedError(
-            "frame_slice is not implemented for VolumetricImagingExtractor due to conflicts with get_video()."
+            "slice_samples is not implemented for VolumetricImagingExtractor due to conflicts with get_series()."
         )
+
+    def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
+        """Return a new VolumetricImagingExtractor with a subset of frames.
+
+        Deprecated
+        ----------
+        This method will be removed in or after October 2025.
+        Use slice_samples() instead.
+        """
+        warnings.warn(
+            "frame_slice() is deprecated and will be removed in or after October 2025. " "Use slice_samples() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.slice_samples(start_sample=start_frame, end_sample=end_frame)
 
 
 class DepthSliceVolumetricImagingExtractor(VolumetricImagingExtractor):

--- a/tests/test_internals/test_slice_samples_imaging.py
+++ b/tests/test_internals/test_slice_samples_imaging.py
@@ -1,0 +1,77 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+
+from roiextractors.testing import generate_dummy_imaging_extractor
+
+
+def test_sample_slicing_imaging_times():
+    num_samples = 10
+    timestamp_shift = 7.1
+    times = np.array(range(num_samples)) + timestamp_shift
+    start_sample, end_sample = 2, 7
+
+    imaging_extractor = generate_dummy_imaging_extractor(
+        num_frames=num_samples, num_rows=5, num_columns=4, num_channels=1
+    )
+    imaging_extractor.set_times(times=times)
+
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=start_sample, end_sample=end_sample)
+    assert_array_equal(
+        sample_sliced_imaging.sample_indices_to_time(
+            sample_indices=np.array([idx for idx in range(sample_sliced_imaging.get_num_samples())])
+        ),
+        times[start_sample:end_sample],
+    )
+
+
+def test_get_image_shape():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_image_shape() == (5, 4)
+
+
+def test_get_num_samples():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_num_samples() == 5
+
+
+def test_get_sampling_frequency():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_sampling_frequency() == 30.0
+
+
+def test_get_channel_names():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_channel_names() == ["channel_num_0"]
+
+
+def test_get_num_channels():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_num_channels() == 1
+
+
+def test_get_frames_assertion():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    with pytest.raises(AssertionError, match="'frame_idxs' range beyond number of available frames!"):
+        sample_sliced_imaging.get_frames(frame_idxs=[6])
+
+
+def test_get_frames():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert_array_equal(
+        sample_sliced_imaging.get_frames(frame_idxs=[2, 4]),
+        imaging_extractor.get_frames(frame_idxs=[4, 6]),
+    )
+
+
+def test_get_dtype():
+    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
+    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
+    assert sample_sliced_imaging.get_dtype() == imaging_extractor.get_dtype()


### PR DESCRIPTION
Replaced frame-based methods with sample-based equivalents to ensure consistency between planar and volumetric data:

- Added `time_to_sample_indices()` (replaces `time_to_frame()`)
- Added `sample_indices_to_time()` (replaces `frame_to_time()`)
- Added `slice_samples()` (replaces `frame_slice()`)
- Added `SliceSamplesImagingExtractor` (replaces `FrameSliceImagingExtractor`)


Fixes #406
