### PR TITLE
Deprecate `ScanImageTiffImagingExtractor`  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Deprecations
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
-* `ScanImageTiffImagingExtractor` is deprecated. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #](https://github.com/catalystneuro/roiextractors/pull/)
+* `ScanImageTiffImagingExtractor` is deprecated. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #431](https://github.com/catalystneuro/roiextractors/pull/431)
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Deprecations
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
+* `ScanImageTiffImagingExtractor` is deprecated. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #](https://github.com/catalystneuro/roiextractors/pull/)
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
 * Fixed `get_series` method in `MemmapImagingExtractor` to preserve channel dimension [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Fix memory estimation for volumetric imaging extractors in their `_repr_` [PR #422](https://github.com/catalystneuro/roiextractors/pull/433)
 
-### Deprecations
+### Deprecations And Removals
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
-* `ScanImageTiffImagingExtractor` is deprecated. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #431](https://github.com/catalystneuro/roiextractors/pull/431)
+* Long deprecated `ScanImageTiffImagingExtractor` is removed. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #431](https://github.com/catalystneuro/roiextractors/pull/431)
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)

--- a/src/roiextractors/extractorlist.py
+++ b/src/roiextractors/extractorlist.py
@@ -15,7 +15,7 @@ from .extractors.simaextractor import SimaSegmentationExtractor
 from .extractors.suite2p import Suite2pSegmentationExtractor
 from .extractors.tiffimagingextractors import (
     TiffImagingExtractor,
-    ScanImageTiffImagingExtractor,
+    ScanImageLegacyImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneMultiFileImagingExtractor,
@@ -39,7 +39,7 @@ imaging_extractor_full_list = [
     NumpyImagingExtractor,
     Hdf5ImagingExtractor,
     TiffImagingExtractor,
-    ScanImageTiffImagingExtractor,
+    ScanImageLegacyImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneMultiFileImagingExtractor,

--- a/src/roiextractors/extractors/tiffimagingextractors/__init__.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/__init__.py
@@ -17,7 +17,7 @@ Classes
 -------
 TiffImagingExtractor
     A ImagingExtractor for TIFF files.
-ScanImageTiffImagingExtractor
+ScanImageLegacyImagingExtractor
     Legacy extractor for reading TIFF files produced via ScanImage v3.8.
 ScanImageTiffSinglePlaneImagingExtractor
     Specialized extractor for reading single-plane TIFF files produced via ScanImage.
@@ -39,7 +39,7 @@ ThorTiffImagingExtractor
 
 from .tiffimagingextractor import TiffImagingExtractor
 from .scanimagetiffimagingextractor import (
-    ScanImageTiffImagingExtractor,
+    ScanImageLegacyImagingExtractor,
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
     ScanImageTiffSinglePlaneMultiFileImagingExtractor,

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -2,7 +2,7 @@
 
 Classes
 -------
-ScanImageTiffImagingExtractor
+ScanImageLegacyImagingExtractor
     Specialized extractor for reading TIFF files produced via ScanImage.
 """
 
@@ -1390,7 +1390,7 @@ class ScanImageTiffSinglePlaneImagingExtractor(ImagingExtractor):
         return raw_index
 
 
-class ScanImageTiffImagingExtractor(ImagingExtractor):  # TODO: Remove this extractor on/after December 2023
+class ScanImageLegacyImagingExtractor(ImagingExtractor):
     """Specialized extractor for reading TIFF files produced via ScanImage.
 
     This implementation is for legacy purposes and is not recommended for use.
@@ -1406,7 +1406,7 @@ class ScanImageTiffImagingExtractor(ImagingExtractor):  # TODO: Remove this extr
         file_path: PathType,
         sampling_frequency: FloatType,
     ):
-        """Create a ScanImageTiffImagingExtractor instance from a TIFF file produced by ScanImage.
+        """Create a ScanImageLegacyImagingExtractor instance from a TIFF file produced by ScanImage.
 
         This extractor allows for lazy accessing of slices, unlike
         :py:class:`~roiextractors.extractors.tiffimagingextractors.TiffImagingExtractor`.

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -1397,9 +1397,7 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
     Please use ScanImageTiffSinglePlaneImagingExtractor or ScanImageTiffMultiPlaneImagingExtractor instead.
     """
 
-    extractor_name = "ScanImageTiffImaging"
-    is_writable = True
-    mode = "file"
+    extractor_name = "ScanImageLegacyImagingExtractor"
 
     def __init__(
         self,
@@ -1419,12 +1417,6 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
         sampling_frequency : float
             The frequency at which the frames were sampled, in Hz.
         """
-        deprecation_message = """
-        This extractor is being deprecated on or after December 2023 in favor of
-        ScanImageTiffMultiPlaneImagingExtractor or ScanImageTiffSinglePlaneImagingExtractor.  Please use one of these
-        extractors instead.
-        """
-        warn(deprecation_message, category=FutureWarning)
         ScanImageTiffReader = _get_scanimage_reader()
 
         super().__init__()
@@ -1433,10 +1425,11 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
         valid_suffixes = [".tiff", ".tif", ".TIFF", ".TIF"]
         if self.file_path.suffix not in valid_suffixes:
             suffix_string = ", ".join(valid_suffixes[:-1]) + f", or {valid_suffixes[-1]}"
-            warn(
+            warning_message = (
                 f"Suffix ({self.file_path.suffix}) is not of type {suffix_string}! "
-                f"The {self.extractor_name}Extractor may not be appropriate for the file."
+                f"The {self.extractor_name} may not be appropriate for the file."
             )
+            warn(warning_message, UserWarning, stacklevel=2)
 
         with ScanImageTiffReader(str(self.file_path)) as io:
             shape = io.shape()  # [frames, rows, columns]

--- a/tests/test_scan_image_tiff.py
+++ b/tests/test_scan_image_tiff.py
@@ -6,7 +6,7 @@ from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal
 import pytest
 
-from roiextractors import TiffImagingExtractor, ScanImageTiffImagingExtractor
+from roiextractors import TiffImagingExtractor, ScanImageLegacyImagingExtractor
 from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import _get_scanimage_reader
 from .setup_paths import OPHYS_DATA_PATH
 
@@ -24,7 +24,7 @@ class TestScanImageTiffExtractor(TestCase):
     def setUpClass(cls):
         cls.file_path = OPHYS_DATA_PATH / "imaging_datasets" / "Tif" / "sample_scanimage.tiff"
         cls.tmpdir = Path(mkdtemp())
-        cls.imaging_extractor = ScanImageTiffImagingExtractor(file_path=cls.file_path, sampling_frequency=30.0)
+        cls.imaging_extractor = ScanImageLegacyImagingExtractor(file_path=cls.file_path, sampling_frequency=30.0)
         ScanImageTiffReader = _get_scanimage_reader()
         with ScanImageTiffReader(filename=str(cls.imaging_extractor.file_path)) as io:
             cls.data = io.data()
@@ -51,10 +51,10 @@ class TestScanImageTiffExtractor(TestCase):
             warn_type=UserWarning,
             exc_msg=(
                 "Suffix (.jpg) is not of type .tiff, .tif, .TIFF, or .TIF! "
-                "The ScanImageTiffImagingExtractor may not be appropriate for the file."
+                "The ScanImageLegacyImagingExtractor may not be appropriate for the file."
             ),
         ):
-            ScanImageTiffImagingExtractor(file_path=different_suffix_file_path, sampling_frequency=30.0)
+            ScanImageLegacyImagingExtractor(file_path=different_suffix_file_path, sampling_frequency=30.0)
 
     def test_scan_image_tiff_consecutive_frames(self):
         frame_idxs = [6, 8]


### PR DESCRIPTION
Use `ScanImageLegacyImagingExtractor` 

See this comment:
https://github.com/catalystneuro/roiextractors/issues/413#issuecomment-2867961885

Dev tests will fail because we are still using this is in neuroconv. I will fix this after we release.