### PR TITLE
deprecate scan image old extractor classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
 * Long deprecated `ScanImageTiffImagingExtractor` is removed. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #431](https://github.com/catalystneuro/roiextractors/pull/431)
-* Deprecated `ScanImageTiffMultiPlaneMultiFileImagingExtractor`, `ScanImageTiffSinglePlaneMultiFileImagingExtractor`, `ScanImageTiffMultiPlaneImagingExtractor`, and `ScanImageTiffSinglePlaneImagingExtractor` classes. These will be removed on or after October 2025. Use `ScanImageImagingExtractor` instead.
+* Deprecated `ScanImageTiffMultiPlaneMultiFileImagingExtractor`, `ScanImageTiffSinglePlaneMultiFileImagingExtractor`, `ScanImageTiffMultiPlaneImagingExtractor`, and `ScanImageTiffSinglePlaneImagingExtractor` classes. These will be removed on or after October 2025. Use `ScanImageImagingExtractor` instead. [PR #432](https://github.com/catalystneuro/roiextractors/pull/432)
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * The `get_video(start_frame, end_frame)` method is deprecated and will be removed in or after September 2025. Use `get_series(start_sample, end_sample)` instead for consistent naming with `get_num_samples`. [PR #416](https://github.com/catalystneuro/roiextractors/pull/416)
 * Python 3.9 is no longer supported [PR #423](https://github.com/catalystneuro/roiextractors/pull/423)
 * Long deprecated `ScanImageTiffImagingExtractor` is removed. For ScanImage legacy data use `ScanImageLegacyImagingExtractor` [PR #431](https://github.com/catalystneuro/roiextractors/pull/431)
+* Deprecated `ScanImageTiffMultiPlaneMultiFileImagingExtractor`, `ScanImageTiffSinglePlaneMultiFileImagingExtractor`, `ScanImageTiffMultiPlaneImagingExtractor`, and `ScanImageTiffSinglePlaneImagingExtractor` classes. These will be removed on or after October 2025. Use `ScanImageImagingExtractor` instead.
 
 ### Improvements
 * Improved criteria for determining if a ScanImage dataset is volumetric by checking both `SI.hStackManager.enable` and `SI.hStackManager.numSlices > 1`[PR #425](https://github.com/catalystneuro/roiextractors/pull/425)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -912,6 +912,11 @@ class ScanImageTiffMultiPlaneMultiFileImagingExtractor(MultiImagingExtractor):
     def __init__(
         self, folder_path: PathType, file_pattern: str, channel_name: str, extract_all_metadata: bool = True
     ) -> None:
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated and will be removed on or after October 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Create a ScanImageTiffMultiPlaneMultiFileImagingExtractor instance from a folder of TIFF files produced by ScanImage.
 
         Parameters
@@ -990,6 +995,11 @@ class ScanImageTiffSinglePlaneMultiFileImagingExtractor(MultiImagingExtractor):
         plane_name: str,
         extract_all_metadata: bool = True,
     ) -> None:
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated and will be removed on or after October 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Create a ScanImageTiffSinglePlaneMultiFileImagingExtractor instance from a folder of TIFF files produced by ScanImage.
 
         Parameters
@@ -1044,6 +1054,11 @@ class ScanImageTiffMultiPlaneImagingExtractor(VolumetricImagingExtractor):
         metadata: Optional[dict] = None,
         parsed_metadata: Optional[dict] = None,
     ) -> None:
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated and will be removed on or after October 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Create a ScanImageTiffMultPlaneImagingExtractor instance from a volumetric TIFF file produced by ScanImage.
 
         Parameters
@@ -1156,6 +1171,11 @@ class ScanImageTiffSinglePlaneImagingExtractor(ImagingExtractor):
         metadata: Optional[dict] = None,
         parsed_metadata: Optional[dict] = None,
     ) -> None:
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated and will be removed on or after October 2025.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         """Create a ScanImageTiffImagingExtractor instance from a TIFF file produced by ScanImage.
 
         The underlying data is stored in a round-robin format collapsed into 3 dimensions (frames, rows, columns).


### PR DESCRIPTION
Should close #413

See https://github.com/catalystneuro/roiextractors/issues/413#issuecomment-2873159847