### PR TITLE
add `get_original_frame_indices` to `ScanImageImagingExtractor` for synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.5.14 (Upcoming)
 
 ### Features
-
+* Added `get_original_frame_indices()` method to `ScanImageImagingExtractor` for mapping extractor samples back to original frame indices in raw microscopy data. This method can be used to synchronize with other data sources or for advanced analysis that requires knowledge of the original frame indices. [PR #445](https://github.com/catalystneuro/roiextractors/pull/445)
 
 ### Fixes
 * Added missing function to retrieve inscopix metadata [PR #436](https://github.com/catalystneuro/roiextractors/pull/436)

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -891,6 +891,80 @@ class ScanImageImagingExtractor(ImagingExtractor):
         frames_per_slice = non_varying_frame_metadata.get("SI.hStackManager.framesPerSlice", 1)
         return frames_per_slice
 
+    def get_original_frame_indices(self, plane_index: Optional[int] = None) -> np.ndarray:
+        """
+        Get the original frame indices for each sample.
+
+        Returns the index of the original frame for each sample, mapping processed samples
+        back to their corresponding frames in the raw microscopy data. This accounts for
+        any filtering, subsampling, or exclusions (such as flyback frames) performed by
+        the extractor.
+
+        Parameters
+        ----------
+        plane_index : int, optional
+            Which plane to use for frame index calculation in volumetric data.
+            If None, uses the convention of using the last plane as its the default for
+            volumetric data. It must be less than the total number of planes.
+
+        Returns
+        -------
+        np.ndarray
+            Array of original frame indices (dtype: int64) with length equal to the
+            number of samples. Each element represents the index of the original
+            microscopy frame that corresponds to that sample.
+
+        Notes
+        -----
+        **Frame Index Calculation:**
+
+        - **Planar data**: Frame indices are sequential (0, 1, 2, ...)
+        - **Multi-channel data**: Accounts for channel interleaving
+        - **Volumetric data**: Uses the specified plane (default: last plane)
+        - **Multi-file data**: Includes file offsets for global indexing
+        - **Flyback frames**: Automatically excluded from indexing
+
+        **Common Use Cases:**
+
+        - Synchronizing with external timing systems
+        - Mapping back to original acquisition timestamps
+        - Data provenance and traceability
+        - Cross-referencing with raw data files
+
+        **Examples:**
+
+        For a 3-sample volumetric dataset with 5 planes per volume:
+        - Default behavior returns indices [4, 9, 14] (last plane of each volume)
+        - With plane_index=0 returns indices [0, 5, 10] (first plane of each volume)
+        """
+        num_planes = self.get_num_planes()
+        if plane_index is not None:
+            assert plane_index < num_planes, f"Plane index {plane_index} exceeds number of planes {num_planes}."
+        else:
+            plane_index = num_planes - 1
+
+        # Initialize array to store timestamps
+        num_samples = self.get_num_samples()
+        frame_indices = np.zeros(num_samples, dtype=np.int64)
+
+        # For each sample, extract its timestamp from the corresponding file and IFD
+        for sample_index in range(num_samples):
+
+            # Get the last frame in this sample to get the timestamps
+            frame_index = sample_index * num_planes + plane_index
+            table_row = self._frames_to_ifd_table[frame_index]
+
+            file_index = table_row["file_index"]
+            ifd_index = table_row["IFD_index"]
+
+            # The ifds are local within a file, so we need to add and offset
+            # equal to the number of IFDs in the previous files
+            file_offset = sum(self._ifds_per_file[:file_index]) if file_index > 0 else 0
+
+            frame_indices[sample_index] = ifd_index + file_offset
+
+        return frame_indices
+
     def __del__(self):
         """Close file handles when the extractor is garbage collected."""
         if hasattr(self, "_tiff_readers"):

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -904,8 +904,7 @@ class ScanImageImagingExtractor(ImagingExtractor):
         ----------
         plane_index : int, optional
             Which plane to use for frame index calculation in volumetric data.
-            If None, uses the convention of using the last plane as its the default for
-            volumetric data. It must be less than the total number of planes.
+            If None, plane_index is set to the last plane in the volume. This is because the timestamp of the acquisition of the last plane in a volume is typically set as the timestamp of the volume as a whole. It must be less than the total number of planes.
 
         Returns
         -------
@@ -934,8 +933,8 @@ class ScanImageImagingExtractor(ImagingExtractor):
         **Examples:**
 
         For a 3-sample volumetric dataset with 5 planes per volume:
-        - Default behavior returns indices [4, 9, 14] (last plane of each volume)
-        - With plane_index=0 returns indices [0, 5, 10] (first plane of each volume)
+        - Default behavior returns indices [4, 9, 14] (last plane of each volumetric sample)
+        - With plane_index=0 returns indices [0, 5, 10] (first plane of each volumetric sample)
         """
         num_planes = self.get_num_planes()
         if plane_index is not None:


### PR DESCRIPTION
The KIM lab has precise synchronized timestamps for every frame derived from TTL signals and needs to map the extractor samples back to their original frame indices in the raw microscopy data for synchronization. See here:

https://github.com/catalystneuro/cohen-u01-to-nwb/blob/b2dbec7de580cc04e748d5b7047a59d5906f55b0/src/kim_lab_to_nwb/kim_conversion.py#L148-L153

This PR adds the `get_original_microscopy_frames_for_samples()` method to `ScanImageImagingExtractor` which returns an array of original frame indices corresponding to each processed samples:

The method is quite simple but most of the work of the PR is in adding test cases for the various possible configurations and experimental setups that the extractor covers.


