### PR TITLE
`ScanImage` fix overflow error on `get_original_frames`

### DIFF
--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -953,8 +953,8 @@ class ScanImageImagingExtractor(ImagingExtractor):
             frame_index = sample_index * num_planes + plane_index
             table_row = self._frames_to_ifd_table[frame_index]
 
-            file_index = table_row["file_index"]
-            ifd_index = table_row["IFD_index"]
+            file_index = int(table_row["file_index"])
+            ifd_index = int(table_row["IFD_index"])
 
             # The ifds are local within a file, so we need to add and offset
             # equal to the number of IFDs in the previous files


### PR DESCRIPTION

File index and ifd index are uint16 so they largest value is 65,535.

https://github.com/catalystneuro/roiextractors/blob/8d99e75688d40727fa3196147afe03b28269f6c9/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py#L369-L378

This means that the newly added method in https://github.com/catalystneuro/roiextractors/pull/445 can overflow when two uint16 values are added:

https://github.com/catalystneuro/roiextractors/blob/8d99e75688d40727fa3196147afe03b28269f6c9/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py#L963

This PR fixes transforms them to python integers to avoid this condition.

