### PR TITLE
Remove num channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 ### Deprecations And Removals
+* Remove deprecated `get_num_channels()` method from `ImagingExtractor` [PR #484](https://github.com/catalystneuro/roiextractors/pull/484)
 
 ### Improvements
 * Refactor Femtonics Imaging Extractor session, munit and channel selection logic. Added missing stub files (`single_channel.mesc` and `single_m_unit_index`)[PR #479](https://github.com/catalystneuro/roiextractors/pull/479)

--- a/docs/source/build_ie.rst
+++ b/docs/source/build_ie.rst
@@ -4,7 +4,6 @@ Build an ImagingExtractor:
 To build your custom ImagingExtractor to interface with a new raw image storage format from your microscope, build a custom class inheriting from a base class that enforces certain methods that need to be defined:
 
 * `get_channel_names()`: returns a list of channel names
-* `get_num_channels()`: returns the number of channels used in the recording
 * `get_num_samples()`: the number of image frames recorded
 * `get_image_size()`: the y,x dim of the image(the resolution)
 * `get_frames()`: return specific requested image frames
@@ -23,7 +22,6 @@ To build your custom ImagingExtractor to interface with a new raw image storage 
 
             self.sampling_frequency = sampling_frequency or # define your own method of extraction
             self._data = self._load_data()  # groups is a list or a np.array with length num_channels
-            self._channel_names = [f'channel_{ch}' for ch in range(self.get_num_channels())] # write logic to get channel names
 
         def _load_data(self):
 
@@ -36,10 +34,6 @@ To build your custom ImagingExtractor to interface with a new raw image storage 
             # channel_ids = range(num_channels)
 
             return self._channel_names
-
-        def get_num_channels(self) -> int:
-            # define method to find the number of channels
-            # returns int
 
         def get_num_samples(self):
 
@@ -56,6 +50,6 @@ To build your custom ImagingExtractor to interface with a new raw image storage 
             # define a method to read a frame from the given frame numbers requested.
             return self._data[frame_idxs]
 
-        def get_image_size(self)
+        def get_frame_shape(self)
 
             # returns something like self._data.shape[1:]

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -480,7 +480,7 @@ def write_to_h5_dataset_format(
         if save_path.suffix == "":
             # when suffix is already raw/bin/dat do not change it.
             save_path = save_path.parent / (save_path.name + ".h5")
-    num_channels = imaging.get_num_channels()
+    num_channels = 1
     num_frames = imaging.get_num_samples()
     size_x, size_y = imaging.get_image_size()
 

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -232,9 +232,6 @@ class Hdf5ImagingExtractor(ImagingExtractor):
     def get_channel_names(self):
         return self._channel_names
 
-    def get_num_channels(self):
-        return self._num_channels
-
     def get_native_timestamps(
         self, start_sample: Optional[int] = None, end_sample: Optional[int] = None
     ) -> Optional[np.ndarray]:

--- a/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
+++ b/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
@@ -66,10 +66,6 @@ class InscopixImagingExtractor(ImagingExtractor):
         warnings.warn("isx only supports single channel videos.")
         return ["channel_0"]
 
-    def get_num_channels(self) -> int:
-        warnings.warn("isx only supports single channel videos.")
-        return 1
-
     def get_series(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None) -> np.ndarray:
         start_sample = start_sample or 0
         end_sample = end_sample or self.get_num_samples()

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -143,14 +143,6 @@ class MemmapImagingExtractor(ImagingExtractor):
     def get_channel_names(self):
         pass
 
-    def get_num_channels(self) -> int:
-        warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._num_channels
-
     def get_dtype(self) -> DtypeType:
         return self.dtype
 
@@ -226,7 +218,7 @@ class MemmapImagingExtractor(ImagingExtractor):
             buffer_size_in_bytes = int(buffer_size_in_bytes)
             type_size = np.dtype(dtype).itemsize
 
-            n_channels = imaging.get_num_channels()
+            n_channels = 1
             pixels_per_frame = n_channels * np.prod(imaging.get_image_size())
             bytes_per_frame = type_size * pixels_per_frame
             frames_in_buffer = buffer_size_in_bytes // bytes_per_frame

--- a/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
+++ b/src/roiextractors/extractors/miniscopeimagingextractor/miniscopeimagingextractor.py
@@ -158,9 +158,6 @@ class _MiniscopeSingleVideoExtractor(ImagingExtractor):
         )
         return self.get_num_samples()
 
-    def get_num_channels(self) -> int:
-        return 1
-
     def get_image_shape(self) -> Tuple[int, int]:
         """Get the shape of the video frame (num_rows, num_columns).
 

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -229,9 +229,6 @@ class NumpyImagingExtractor(ImagingExtractor):
     def get_channel_names(self):
         return self._channel_names
 
-    def get_num_channels(self):
-        return self._num_channels
-
     def get_native_timestamps(
         self, start_sample: Optional[int] = None, end_sample: Optional[int] = None
     ) -> Optional[np.ndarray]:

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -308,9 +308,6 @@ class NwbImagingExtractor(ImagingExtractor):
     def get_channel_names(self):
         return self._channel_names
 
-    def get_num_channels(self):
-        return self._num_channels
-
     def get_native_timestamps(
         self, start_sample: Optional[int] = None, end_sample: Optional[int] = None
     ) -> Optional[np.ndarray]:

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -283,9 +283,6 @@ class SbxImagingExtractor(ImagingExtractor):
     def get_channel_names(self) -> list:
         return self._channel_names
 
-    def get_num_channels(self) -> int:
-        return self._info["nChan"]
-
     @staticmethod
     def write_imaging(imaging, save_path: PathType, overwrite: bool = False):
         """Write a SbxImagingExtractor to a `.mat` file.

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -645,9 +645,6 @@ class BrukerTiffSinglePlaneImagingExtractor(MultiImagingExtractor):
     def get_channel_names(self) -> List[str]:
         return self._channel_names
 
-    def get_num_channels(self) -> int:
-        return 1
-
     def get_dtype(self) -> DtypeType:
         return self._dtype
 
@@ -707,9 +704,6 @@ class _BrukerTiffSinglePlaneImagingExtractor(ImagingExtractor):
             stacklevel=2,
         )
         return self.get_num_samples()
-
-    def get_num_channels(self) -> int:
-        return 1
 
     def get_image_shape(self) -> Tuple[int, int]:
         """Get the shape of the video frame (num_rows, num_columns).

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -209,9 +209,6 @@ class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
     def get_channel_names(self) -> list:
         return self._channel_names
 
-    def get_num_channels(self) -> int:
-        return self._num_channels
-
     def get_dtype(self) -> DtypeType:
         return self._dtype
 
@@ -272,9 +269,6 @@ class _MicroManagerTiffImagingExtractor(ImagingExtractor):
             stacklevel=2,
         )
         return self.get_num_samples()
-
-    def get_num_channels(self) -> int:
-        return 1
 
     def get_image_shape(self) -> Tuple[int, int]:
         """Get the shape of the video frame (num_rows, num_columns).

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -1530,9 +1530,6 @@ class ScanImageTiffSinglePlaneImagingExtractor(ImagingExtractor):
     def get_channel_names(self) -> list:
         return self._channel_names
 
-    def get_num_channels(self) -> int:
-        return self._num_channels
-
     def get_num_planes(self) -> int:
         """Get the number of depth planes.
 
@@ -1803,9 +1800,6 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
 
     def get_sampling_frequency(self) -> float:
         return self._sampling_frequency
-
-    def get_num_channels(self) -> int:
-        return self._num_channels
 
     def get_channel_names(self) -> list:
         pass

--- a/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/thortiffimagingextractor.py
@@ -320,10 +320,6 @@ class ThorTiffImagingExtractor(ImagingExtractor):
         """Return the sampling frequency, if available."""
         return self._sampling_frequency
 
-    def get_num_channels(self) -> int:
-        """Return the number of channels."""
-        return self._num_channels
-
     def get_channel_names(self) -> List[str]:
         """Return the channel names."""
         return self._channel_names

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -192,14 +192,6 @@ class TiffImagingExtractor(ImagingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
-    def get_num_channels(self):
-        warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._num_channels
-
     def get_channel_names(self):
         pass
 

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -786,25 +786,6 @@ class SampleSlicedImagingExtractor(ImagingExtractor):
     def get_channel_names(self) -> list:
         return self._parent_imaging.get_channel_names()
 
-    def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
-        warnings.warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._parent_imaging.get_num_channels()
-
     def get_num_planes(self) -> int:
         """Get the number of depth planes.
 
@@ -976,25 +957,6 @@ class FrameSliceImagingExtractor(SampleSlicedImagingExtractor):
 
     def get_channel_names(self) -> list:
         return self._parent_imaging.get_channel_names()
-
-    def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
-        warnings.warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._parent_imaging.get_num_channels()
 
     def get_num_planes(self) -> int:
         """Get the number of depth planes.

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -236,24 +236,6 @@ class ImagingExtractor(ABC):
         """
         pass
 
-    def get_num_channels(self) -> int:
-        """Get the total number of active channels in the recording.
-
-        Returns
-        -------
-        num_channels: int
-            Integer count of number of channels.
-
-        Deprecated
-        ----------
-        This method will be removed in or after August 2025.
-        """
-        warnings.warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     def get_dtype(self) -> DtypeType:
         """Get the data type of the video.
 

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -20,7 +20,6 @@ class MultiImagingExtractor(ImagingExtractor):
     """Class to combine multiple ImagingExtractor objects by frames."""
 
     extractor_name = "MultiImagingExtractor"
-    installation_mesg = ""
 
     def __init__(self, imaging_extractors: List[ImagingExtractor]):
         """Initialize a MultiImagingExtractor object from a list of ImagingExtractors.
@@ -316,14 +315,6 @@ class MultiImagingExtractor(ImagingExtractor):
 
     def get_channel_names(self) -> list:
         return self._imaging_extractors[0].get_channel_names()
-
-    def get_num_channels(self) -> int:
-        warnings.warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._imaging_extractors[0].get_num_channels()
 
     def get_native_timestamps(
         self, start_sample: Optional[int] = None, end_sample: Optional[int] = None

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -477,13 +477,12 @@ def assert_get_frames_return_shape(imaging_extractor: ImagingExtractor):
 def check_imaging_return_types(img_ex: ImagingExtractor):
     """Check that the return types of the imaging extractor are correct."""
     assert isinstance(img_ex.get_num_samples(), inttype)
-    assert isinstance(img_ex.get_num_channels(), inttype)
     assert isinstance(img_ex.get_sampling_frequency(), floattype)
     _assert_iterable_complete(
         iterable=img_ex.get_channel_names(),
         dtypes=(list, NoneType),
         element_dtypes=str,
-        shape_max=(img_ex.get_num_channels(),),
+        shape_max=(1,),
     )
     _assert_iterable_complete(iterable=img_ex.get_image_size(), dtypes=Iterable, element_dtypes=inttype, shape=(2,))
 

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -58,7 +58,6 @@ class VolumetricImagingExtractor(ImagingExtractor):
         properties_to_check = dict(
             get_sampling_frequency="The sampling frequency",
             get_image_shape="The shape of a frame",
-            get_num_channels="The number of channels",
             get_channel_names="The name of the channels",
             get_dtype="The data type",
             get_num_samples="The number of samples",
@@ -227,14 +226,6 @@ class VolumetricImagingExtractor(ImagingExtractor):
 
     def get_channel_names(self) -> list:
         return self._imaging_extractors[0].get_channel_names()
-
-    def get_num_channels(self) -> int:
-        warnings.warn(
-            "get_num_channels() is deprecated and will be removed in or after August 2025.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._imaging_extractors[0].get_num_channels()
 
     def get_dtype(self) -> DtypeType:
         return self._imaging_extractors[0].get_dtype()

--- a/tests/test_brukertiffimagingextactor.py
+++ b/tests/test_brukertiffimagingextactor.py
@@ -92,9 +92,6 @@ class TestBrukerTiffExtractorSinglePlaneCase(TestCase):
     def test_brukertiffextractor_channel_names(self):
         self.assertEqual(self.extractor.get_channel_names(), ["Ch2"])
 
-    def test_brukertiffextractor_num_channels(self):
-        self.assertEqual(self.extractor.get_num_channels(), 1)
-
     def test_brukertiffextractor_dtype(self):
         self.assertEqual(self.extractor.get_dtype(), np.uint16)
 
@@ -152,9 +149,6 @@ class TestBrukerTiffExtractorDualPlaneCase(TestCase):
 
     def test_brukertiffextractor_channel_names(self):
         self.assertEqual(self.extractor.get_channel_names(), ["Ch2"])
-
-    def test_brukertiffextractor_num_channels(self):
-        self.assertEqual(self.extractor.get_num_channels(), 1)
 
     def test_brukertiffextractor_dtype(self):
         self.assertEqual(self.extractor.get_dtype(), np.uint16)

--- a/tests/test_inscopiximagingextractor.py
+++ b/tests/test_inscopiximagingextractor.py
@@ -54,7 +54,6 @@ def test_inscopiximagingextractor_movie_128x128x100_part1():
     assert extractor.get_dtype() is dtype("float32")
     assert extractor.get_sampling_frequency() == 10.0
     assert extractor.get_channel_names() == ["channel_0"]
-    assert extractor.get_num_channels() == 1
     assert extractor.get_series().shape == (100, 128, 128)
 
     # Test retrieving multiple samples
@@ -134,7 +133,6 @@ def test_inscopiximagingextractor_movie_longer_than_3_min():
     assert extractor.get_dtype() is dtype("uint16")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 5.5563890139076415)
     assert extractor.get_channel_names() == ["channel_0"]
-    assert extractor.get_num_channels() == 1
     assert extractor.get_series().shape == (1248, 33, 29)
 
     # Test retrieving multiple samples
@@ -222,7 +220,6 @@ def test_inscopiximagingextractor_movie_u8():
     assert extractor.get_dtype() is dtype("uint8")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 20.0)
     assert extractor.get_channel_names() == ["channel_0"]
-    assert extractor.get_num_channels() == 1
     assert extractor.get_series().shape == (5, 3, 4)
 
     # Test retrieving multiple samples
@@ -309,7 +306,6 @@ def test_inscopiximagingextractor_multiplane_movie():
     assert extractor.get_dtype() is dtype("uint16")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 7.002533951423664, decimal=10)
     assert extractor.get_channel_names() == ["channel_0"]
-    assert extractor.get_num_channels() == 1
     assert extractor.get_series().shape == (30, 100, 160)
     assert extractor.get_samples([0]).shape == (30, 100, 160)
 
@@ -389,7 +385,6 @@ def test_inscopiximagingextractor_dual_color_movie_with_dropped_frames():
     assert extractor.get_dtype() is dtype("uint16")
     np.testing.assert_almost_equal(extractor.get_sampling_frequency(), 6.000177005221654, decimal=10)
     assert extractor.get_channel_names() == ["channel_0"]
-    assert extractor.get_num_channels() == 1
     assert extractor.get_samples([0]).shape == (25, 288, 480)
     assert extractor.get_series().shape == (25, 288, 480)
 

--- a/tests/test_internals/test_frame_slice_imaging.py
+++ b/tests/test_internals/test_frame_slice_imaging.py
@@ -48,9 +48,6 @@ class TestFrameSliceImaging(TestCase):
     def test_get_channel_names(self):
         assert self.frame_sliced_imaging.get_channel_names() == ["channel_num_0"]
 
-    def test_get_num_channels(self):
-        assert self.frame_sliced_imaging.get_num_channels() == 1
-
     def test_get_samples_assertion(self):
         with self.assertRaisesWith(
             exc_type=AssertionError, exc_msg="'sample_indices' range beyond number of available samples!"

--- a/tests/test_internals/test_nwb_extractors.py
+++ b/tests/test_internals/test_nwb_extractors.py
@@ -70,7 +70,6 @@ class TestNwbImagingExtractor(unittest.TestCase):
 
         image_size = nwb_imaging_extractor.get_image_size()
         num_frames = nwb_imaging_extractor.get_num_frames()
-        num_channels = nwb_imaging_extractor.get_num_channels()
 
         expected_image_size = self.image_size
         expected_num_frames = self.num_frames
@@ -78,7 +77,6 @@ class TestNwbImagingExtractor(unittest.TestCase):
 
         assert image_size == expected_image_size
         assert num_frames == expected_num_frames
-        assert num_channels == expected_num_channels
 
         # Test numpy like behavior for frame_idxs
         frame_idxs = 0

--- a/tests/test_internals/test_slice_samples_imaging.py
+++ b/tests/test_internals/test_slice_samples_imaging.py
@@ -49,12 +49,6 @@ def test_get_channel_names():
     assert sample_sliced_imaging.get_channel_names() == ["channel_num_0"]
 
 
-def test_get_num_channels():
-    imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
-    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
-    assert sample_sliced_imaging.get_num_channels() == 1
-
-
 def test_get_samples_assertion():
     imaging_extractor = generate_dummy_imaging_extractor(num_frames=10, num_rows=5, num_columns=4, num_channels=1)
     sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -90,9 +90,6 @@ class TestMicroManagerTiffExtractor(TestCase):
         for sub_extractor in self.extractor._imaging_extractors:
             self.assertEqual(sub_extractor.get_num_frames(), 5)
 
-    def test_private_micromanagertiffextractor_num_channels(self):
-        self.assertEqual(self.extractor._imaging_extractors[0].get_num_channels(), 1)
-
     def test_private_micromanagertiffextractor_sampling_frequency(self):
         sub_extractor = self.extractor._imaging_extractors[0]
         exc_msg = f"The {sub_extractor.extractor_name}Extractor does not support retrieving the imaging rate."

--- a/tests/test_micromanagertiffimagingextractor.py
+++ b/tests/test_micromanagertiffimagingextractor.py
@@ -77,9 +77,6 @@ class TestMicroManagerTiffExtractor(TestCase):
     def test_micromanagertiffextractor_channel_names(self):
         self.assertEqual(self.extractor.get_channel_names(), ["Default"])
 
-    def test_micromanagertiffextractor_num_channels(self):
-        self.assertEqual(self.extractor.get_num_channels(), 1)
-
     def test_micromanagertiffextractor_dtype(self):
         self.assertEqual(self.extractor.get_dtype(), np.uint16)
 

--- a/tests/test_scan_image_tiff.py
+++ b/tests/test_scan_image_tiff.py
@@ -80,9 +80,6 @@ class TestScanImageTiffExtractor(TestCase):
     def test_scan_image_tiff_image_size(self):
         assert self.imaging_extractor.get_image_size() == (256, 256)
 
-    def test_scan_image_tiff_num_channels(self):
-        assert self.imaging_extractor.get_num_channels() == 1
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scanimagetiffimagingextractor.py
+++ b/tests/test_scanimagetiffimagingextractor.py
@@ -228,11 +228,6 @@ def test_get_sampling_frequency(scan_image_tiff_single_plane_imaging_extractor, 
     assert sampling_frequency == expected_properties["sampling_frequency"]
 
 
-def test_get_num_channels(scan_image_tiff_single_plane_imaging_extractor, expected_properties):
-    num_channels = scan_image_tiff_single_plane_imaging_extractor.get_num_channels()
-    assert num_channels == expected_properties["num_channels"]
-
-
 def test_get_available_planes(scan_image_tiff_single_plane_imaging_extractor, expected_properties):
     file_path = str(scan_image_tiff_single_plane_imaging_extractor.file_path)
     plane_names = ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path)

--- a/tests/test_suite2psegmentationextractor.py
+++ b/tests/test_suite2psegmentationextractor.py
@@ -104,9 +104,6 @@ class TestSuite2pSegmentationExtractor(TestCase):
     def test_optical_channel_names(self):
         self.assertEqual(self.extractor.get_channel_names(), ["Chan1"])
 
-    def test_num_channels(self):
-        self.assertEqual(self.extractor.get_num_channels(), 1)
-
     def test_num_rois(self):
         self.assertEqual(self.extractor.get_num_rois(), self.num_rois)
 


### PR DESCRIPTION
Remove `get_num_channels` from imaging extractors. We deprecated this. Now is the time to remove it.