### PR TITLE
Add has_time_vector method to SampleSlicedSegmentationExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations And Removals
 * Remove deprecated `get_num_channels()` method from `ImagingExtractor` [PR #484](https://github.com/catalystneuro/roiextractors/pull/484)
 * Remove deprecated `write_segmentation()` methods from all segmentation extractors [PR #491](https://github.com/catalystneuro/roiextractors/pull/491)
+* Add `has_time_vector()` method to `SampleSlicedSegmentationExtractor` [PR #494](https://github.com/catalystneuro/roiextractors/pull/494)
 
 ### Improvements
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -847,15 +847,47 @@ class SampleSlicedSegmentationExtractor(SegmentationExtractor):
     def get_native_timestamps(
         self, start_sample: Optional[int] = None, end_sample: Optional[int] = None
     ) -> Optional[np.ndarray]:
-        # Adjust the sample indices to account for the slice offset
+        # Get the full native timestamps from the parent
+        parent_native_timestamps = self._parent_segmentation.get_native_timestamps()
+
+        if parent_native_timestamps is None:
+            return None
+
+        # Slice the parent's native timestamps to match our slice
+        sliced_native_timestamps = parent_native_timestamps[self._start_sample : self._end_sample]
+
+        # Apply the requested start/end sample range within our slice
         start_sample = start_sample or 0
-        end_sample = end_sample or self.get_num_samples()
+        end_sample = end_sample or len(sliced_native_timestamps)
 
-        # Map slice-relative indices to parent indices
-        parent_start = self._start_sample + start_sample
-        parent_end = self._start_sample + end_sample
+        return sliced_native_timestamps[start_sample:end_sample]
 
-        return self._parent_segmentation.get_native_timestamps(start_sample=parent_start, end_sample=parent_end)
+    def get_timestamps(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None) -> np.ndarray:
+        # Set defaults
+        if start_sample is None:
+            start_sample = 0
+        if end_sample is None:
+            end_sample = self.get_num_samples()
+
+        # Use our sliced _times if available
+        if self._times is not None:
+            return self._times[start_sample:end_sample]
+
+        # Check if parent has cached _times and use those
+        if getattr(self._parent_segmentation, "_times") is not None:
+            parent_timestamps = self._parent_segmentation._times[self._start_sample : self._end_sample]
+            self._times = parent_timestamps  # Cache the sliced timestamps
+            return parent_timestamps[start_sample:end_sample]
+
+        # Fall back to getting native timestamps (which will be sliced correctly)
+        native_timestamps = self.get_native_timestamps()
+        if native_timestamps is not None:
+            self._times = native_timestamps  # Cache the sliced native timestamps
+            return native_timestamps[start_sample:end_sample]
+
+        # Fallback to calculated timestamps from sampling frequency
+        sample_indices = np.arange(start_sample, end_sample)
+        return sample_indices / self.get_sampling_frequency()
 
     def has_time_vector(self) -> bool:
         # Override to check parent segmentation for time vector

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -857,6 +857,10 @@ class SampleSlicedSegmentationExtractor(SegmentationExtractor):
 
         return self._parent_segmentation.get_native_timestamps(start_sample=parent_start, end_sample=parent_end)
 
+    def has_time_vector(self) -> bool:
+        # Override to check parent segmentation for time vector
+        return self._parent_segmentation.has_time_vector()
+
 
 class FrameSliceSegmentationExtractor(SampleSlicedSegmentationExtractor):
     """Class to get a lazy frame slice.

--- a/tests/test_miniansegmentationextractor.py
+++ b/tests/test_miniansegmentationextractor.py
@@ -200,3 +200,12 @@ def test_get_session_id(extractor, expected_properties):
     """Test that session ID is correctly retrieved."""
     session_id = extractor._get_session_id()
     assert session_id == expected_properties["session_id"]
+
+
+def test_slicing_preserves_has_time_vector():
+    """Test that slicing preserves the has_time_vector property."""
+    folder_path = OPHYS_DATA_PATH / "segmentation_datasets" / "minian" / "segmented_data_3units_100frames"
+    extractor = MinianSegmentationExtractor(folder_path=folder_path)
+    assert extractor.has_time_vector()
+    sub_extractor = extractor.slice_samples(start_sample=0, end_sample=10)
+    assert sub_extractor.has_time_vector()


### PR DESCRIPTION
Override `has_time_vector` method to check for the presence of a time vector in the parent segmentation extractor.
When defining a `has_time_vector` method in an ad hoc segmentation extractor, tests in `Test[...]SegmentationInterfaceWithStubTest` fail. 
This occurs because `Test[...]SegmentationInterfaceWithStubTest` uses `SampleSlicedSegmentationExtractor`, which defaults to the base `SegmentationExtractor.has_time_vector` implementation rather than the actual implementation of the parent segmentation extractor. For custom implementations like `MinianSegmentationExtractor`, this causes test failures https://github.com/catalystneuro/neuroconv/pull/1107.