### PR TITLE
Add optional sampling frequency and timestamps support to MinianSegmentationExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Improvements
 * Refactored image storage in `SegmentationExtractor` from individual `_image_mean` and `_image_correlation` attributes to unified `_summary_images` dictionary for better extensibility [PR #493](https://github.com/catalystneuro/roiextractors/pull/493)
+* Enhanced `MinianSegmentationExtractor` with optional sampling frequency and timestamps path parameters at construction, improved error handling for missing sampling frequency [PR #497](https://github.com/catalystneuro/roiextractors/pull/497)
 
 # v0.6.2 (August 20th, 2025)
 

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -372,7 +372,9 @@ class MinianSegmentationExtractor(SegmentationExtractor):
                 if len(timestamps) > 1:
                     # Calculate average sampling frequency from time differences
                     derived_freq = calculate_regular_series_rate(timestamps)
-                    return float(derived_freq)
+                    return float(
+                        derived_freq
+                    )  # it will be None if timestamps are irregularly spaced, so _times will be set in get_native_timestamps
             except Exception:
                 pass
 

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -371,7 +371,8 @@ class MinianSegmentationExtractor(SegmentationExtractor):
                 derived_freq = calculate_regular_series_rate(timestamps)
                 if derived_freq is None:
                     warnings.warn(
-                        f"Timestamps are irregularly spaced; cannot derive a sampling frequency from timestamps in {self._timestamps_path}."
+                        f"Timestamps are irregularly spaced; cannot derive a sampling frequency from timestamps in {self._timestamps_path}. Will return None.",
+                        UserWarning,
                     )
                     return None
                 else:

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -348,7 +348,7 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         """
         return dict(self._summary_images)
 
-    def get_sampling_frequency(self) -> float:
+    def get_sampling_frequency(self) -> Optional[float]:
         """Get the sampling frequency in Hz.
 
         Returns
@@ -372,9 +372,13 @@ class MinianSegmentationExtractor(SegmentationExtractor):
                 if len(timestamps) > 1:
                     # Calculate average sampling frequency from time differences
                     derived_freq = calculate_regular_series_rate(timestamps)
-                    return float(
-                        derived_freq
-                    )  # it will be None if timestamps are irregularly spaced, so _times will be set in get_native_timestamps
+                    if derived_freq is None:
+                        warnings.warn(
+                            f"Timestamps are irregularly spaced; cannot derive a sampling frequency from timestamps in {self._timestamps_path}."
+                        )
+                        return None
+                    else:
+                        return float(derived_freq)
             except Exception:
                 pass
 

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -12,8 +12,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-import zarr
-from neuroconv.utils import calculate_regular_series_rate
+
 
 from ...extraction_tools import FloatType, PathType
 from ...segmentationextractor import SegmentationExtractor
@@ -66,6 +65,8 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         timestamps_path: str or Path, optional
             Path to the timeStamps.csv file. If not provided, assumes default location at folder_path/timeStamps.csv.
         """
+        import zarr
+
         SegmentationExtractor.__init__(self)
         self.folder_path = Path(folder_path)
         self._sampling_frequency = sampling_frequency
@@ -360,6 +361,8 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         ValueError
             If no sampling frequency is available and timestamps cannot be used to derive it.
         """
+        from neuroconv.utils import calculate_regular_series_rate
+
         if self._sampling_frequency is not None:
             return float(self._sampling_frequency)
 

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -48,16 +48,19 @@ class MinianSegmentationExtractor(SegmentationExtractor):
 
     extractor_name = "MinianSegmentation"
 
-    def __init__(self, folder_path: PathType):
+    def __init__(self, folder_path: PathType, sampling_frequency: Optional[float] = None):
         """Initialize a MinianSegmentationExtractor instance.
 
         Parameters
         ----------
         folder_path: str or Path
             The location of the folder containing minian .zarr output.
+        sampling_frequency: float, optional
+            The sampling frequency in Hz. If not provided, will attempt to derive from timeStamps.csv.
         """
         SegmentationExtractor.__init__(self)
         self.folder_path = Path(folder_path)
+        self._sampling_frequency = sampling_frequency
         self._roi_response_denoised = self._read_trace_from_zarr_field(field="C")
         self._roi_response_baseline = self._read_trace_from_zarr_field(field="b0")
         self._roi_response_neuropil = self._read_trace_from_zarr_field(field="f")

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -365,21 +365,17 @@ class MinianSegmentationExtractor(SegmentationExtractor):
 
         # If no sampling frequency provided, try to derive from timestamps
         if self._timestamps_path.exists():
-            try:
-                # Try to calculate sampling frequency from timestamps
-                timestamps = self.get_native_timestamps()
-                if len(timestamps) > 1:
-                    # Calculate average sampling frequency from time differences
-                    derived_freq = calculate_regular_series_rate(timestamps)
-                    if derived_freq is None:
-                        warnings.warn(
-                            f"Timestamps are irregularly spaced; cannot derive a sampling frequency from timestamps in {self._timestamps_path}."
-                        )
-                        return None
-                    else:
-                        return float(derived_freq)
-            except Exception:
-                pass
+            timestamps = self.get_native_timestamps()
+            if len(timestamps) > 1:
+                # Calculate average sampling frequency from time differences
+                derived_freq = calculate_regular_series_rate(timestamps)
+                if derived_freq is None:
+                    warnings.warn(
+                        f"Timestamps are irregularly spaced; cannot derive a sampling frequency from timestamps in {self._timestamps_path}."
+                    )
+                    return None
+                else:
+                    return float(derived_freq)
 
     def _get_session_id(self) -> str:
         """Get the session id from the A.zarr group.

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -106,6 +106,14 @@ class MinianSegmentationExtractor(SegmentationExtractor):
                     f"No sampling frequency provided and timestamps file not found at {self._timestamps_path}. "
                     "Please provide either a sampling_frequency parameter or ensure a valid timeStamps.csv file exists."
                 )
+            else:
+                try:
+                    self.get_native_timestamps()
+                except Exception as e:
+                    raise ValueError(
+                        f"Error reading timestamps from {self._timestamps_path}: {e}. "
+                        "Please provide a valid timeStamps.csv file or a sampling_frequency parameter."
+                    )
 
     def _read_zarr_group(self, zarr_group: str):
         """Read the zarr group.
@@ -187,15 +195,6 @@ class MinianSegmentationExtractor(SegmentationExtractor):
             return np.transpose(dataset[field])
         elif dataset[field].ndim == 1:
             return np.expand_dims(dataset[field], axis=1)
-
-    def _read_timestamps_from_csv(self) -> np.ndarray:
-        """Extract timestamps corresponding to frame indexes (not downsampled) of the stored denoised trace.
-
-        Returns
-        -------
-        np.ndarray
-            The timestamps of the denoised trace.
-        """
 
     def get_native_timestamps(self, start_sample: Optional[int] = None, end_sample: Optional[int] = None) -> np.ndarray:
         """
@@ -381,12 +380,6 @@ class MinianSegmentationExtractor(SegmentationExtractor):
                         return float(derived_freq)
             except Exception:
                 pass
-
-        raise ValueError(
-            "No sampling frequency available. Please provide a sampling_frequency parameter "
-            "when initializing the MinianSegmentationExtractor, or ensure a valid timeStamps.csv "
-            "file is available to derive the sampling frequency."
-        )
 
     def _get_session_id(self) -> str:
         """Get the session id from the A.zarr group.

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -13,7 +13,6 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-
 from ...extraction_tools import FloatType, PathType
 from ...segmentationextractor import SegmentationExtractor
 
@@ -65,7 +64,6 @@ class MinianSegmentationExtractor(SegmentationExtractor):
         timestamps_path: str or Path, optional
             Path to the timeStamps.csv file. If not provided, assumes default location at folder_path/timeStamps.csv.
         """
-        import zarr
 
         SegmentationExtractor.__init__(self)
         self.folder_path = Path(folder_path)

--- a/tests/test_miniansegmentationextractor.py
+++ b/tests/test_miniansegmentationextractor.py
@@ -200,3 +200,112 @@ def test_get_session_id(extractor, expected_properties):
     """Test that session ID is correctly retrieved."""
     session_id = extractor._get_session_id()
     assert session_id == expected_properties["session_id"]
+
+
+def test_constructor_with_sampling_frequency(folder_path):
+    """Test that the extractor can be initialized with a sampling frequency."""
+    sampling_freq = 30.0
+    extractor = MinianSegmentationExtractor(folder_path=folder_path, sampling_frequency=sampling_freq)
+    assert extractor.get_sampling_frequency() == sampling_freq
+
+
+def test_constructor_with_custom_timestamps_path(folder_path):
+    """Test that the extractor can be initialized with a custom timestamps path."""
+    timestamps_path = folder_path / "timeStamps.csv"
+    extractor = MinianSegmentationExtractor(folder_path=folder_path, timestamps_path=timestamps_path)
+    # Should work without error and be able to get timestamps
+    timestamps = extractor.get_native_timestamps()
+    assert len(timestamps) > 0
+
+
+def test_constructor_error_no_sampling_freq_no_timestamps(folder_path, tmp_path):
+    """Test that constructor raises error when no sampling frequency and no valid timestamps file."""
+    # Copy all files except timeStamps.csv
+    folders_to_copy = [
+        "A.zarr",
+        "b.zarr",
+        "f.zarr",
+        "C.zarr",
+        "S.zarr",
+        "b0.zarr",
+        "max_proj.zarr",
+        ".zgroup",
+    ]
+
+    for folder in folders_to_copy:
+        src = Path(folder_path) / folder
+        dst = tmp_path / folder
+        if src.is_dir():
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy(src, dst)
+
+    # Should raise error when no sampling frequency and no timestamps file
+    with pytest.raises(
+        ValueError,
+        match=r"No sampling frequency provided and timestamps file not found at .* "
+        r"Please provide either a sampling_frequency parameter or ensure a valid timeStamps\.csv file exists\.",
+    ):
+        MinianSegmentationExtractor(folder_path=tmp_path)
+
+
+def test_constructor_error_no_sampling_freq_invalid_timestamps_path(folder_path):
+    """Test that constructor raises error when no sampling frequency and invalid timestamps path."""
+    invalid_timestamps_path = folder_path / "nonexistent_timestamps.csv"
+
+    with pytest.raises(
+        ValueError,
+        match=r"No sampling frequency provided and timestamps file not found at .* "
+        r"Please provide either a sampling_frequency parameter or ensure a valid timeStamps\.csv file exists\.",
+    ):
+        MinianSegmentationExtractor(folder_path=folder_path, timestamps_path=invalid_timestamps_path)
+
+
+def test_get_sampling_frequency_error_no_data(folder_path, tmp_path):
+    """Test that get_sampling_frequency raises error when no data is available."""
+    # Copy all files except timeStamps.csv
+    folders_to_copy = [
+        "A.zarr",
+        "b.zarr",
+        "f.zarr",
+        "C.zarr",
+        "S.zarr",
+        "b0.zarr",
+        "max_proj.zarr",
+        ".zgroup",
+    ]
+
+    for folder in folders_to_copy:
+        src = Path(folder_path) / folder
+        dst = tmp_path / folder
+        if src.is_dir():
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy(src, dst)
+
+    # Create extractor with sampling frequency to bypass constructor validation
+    extractor = MinianSegmentationExtractor(folder_path=tmp_path, sampling_frequency=30.0)
+
+    # Now remove the sampling frequency and test the method
+    extractor._sampling_frequency = None
+
+    with pytest.raises(
+        ValueError,
+        match=r"No sampling frequency available\. Please provide a sampling_frequency parameter "
+        r"when initializing the MinianSegmentationExtractor, or ensure a valid timeStamps\.csv "
+        r"file is available to derive the sampling frequency\.",
+    ):
+        extractor.get_sampling_frequency()
+
+
+def test_constructor_with_both_sampling_freq_and_timestamps_path(folder_path):
+    """Test that both parameters can be provided and sampling frequency takes precedence."""
+    sampling_freq = 25.0
+    timestamps_path = folder_path / "timeStamps.csv"
+
+    extractor = MinianSegmentationExtractor(
+        folder_path=folder_path, sampling_frequency=sampling_freq, timestamps_path=timestamps_path
+    )
+
+    # Should return the provided sampling frequency, not derived from timestamps
+    assert extractor.get_sampling_frequency() == sampling_freq

--- a/tests/test_miniansegmentationextractor.py
+++ b/tests/test_miniansegmentationextractor.py
@@ -261,43 +261,6 @@ def test_constructor_error_no_sampling_freq_invalid_timestamps_path(folder_path)
         MinianSegmentationExtractor(folder_path=folder_path, timestamps_path=invalid_timestamps_path)
 
 
-def test_get_sampling_frequency_error_no_data(folder_path, tmp_path):
-    """Test that get_sampling_frequency raises error when no data is available."""
-    # Copy all files except timeStamps.csv
-    folders_to_copy = [
-        "A.zarr",
-        "b.zarr",
-        "f.zarr",
-        "C.zarr",
-        "S.zarr",
-        "b0.zarr",
-        "max_proj.zarr",
-        ".zgroup",
-    ]
-
-    for folder in folders_to_copy:
-        src = Path(folder_path) / folder
-        dst = tmp_path / folder
-        if src.is_dir():
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-        else:
-            shutil.copy(src, dst)
-
-    # Create extractor with sampling frequency to bypass constructor validation
-    extractor = MinianSegmentationExtractor(folder_path=tmp_path, sampling_frequency=30.0)
-
-    # Now remove the sampling frequency and test the method
-    extractor._sampling_frequency = None
-
-    with pytest.raises(
-        ValueError,
-        match=r"No sampling frequency available\. Please provide a sampling_frequency parameter "
-        r"when initializing the MinianSegmentationExtractor, or ensure a valid timeStamps\.csv "
-        r"file is available to derive the sampling frequency\.",
-    ):
-        extractor.get_sampling_frequency()
-
-
 def test_constructor_with_both_sampling_freq_and_timestamps_path(folder_path):
     """Test that both parameters can be provided and sampling frequency takes precedence."""
     sampling_freq = 25.0


### PR DESCRIPTION
Fixes #496
Introduce optional parameters for sampling frequency and timestamps path in the MinianSegmentationExtractor. Implement validation for these parameters and enhance error handling. Add tests to ensure correct functionality and error scenarios.

