### PR TITLE
Improve channel and plane selection warning on Suite2p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations And Removals
 
 ### Improvements
+* The `Suite2pSegmentationExtractor` warnings for multiple channels or planes now list the available names and the one being loaded instead of pointing at `get_available_channels` / `get_available_planes`. [PR #607](https://github.com/catalystneuro/roiextractors/pull/607)
 
 # v0.9.0 (June 30th, 2026)
 

--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -94,8 +94,8 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
             if len(channel_names) > 1:
                 # For backward compatibility maybe it is better to warn first
                 warn(
-                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument. "
-                    "To see what channels are available, call `Suite2pSegmentationExtractor.get_available_channels(folder_path=...)`.",
+                    f"More than one channel is detected: {channel_names}. Using '{channel_names[0]}'. "
+                    "Please specify which channel you wish to load with the `channel_name` argument.",
                     UserWarning,
                 )
             channel_name = channel_names[0]
@@ -112,8 +112,8 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
             if len(plane_names) > 1:
                 # For backward compatibility maybe it is better to warn first
                 warn(
-                    "More than one plane is detected! Please specify which plane you wish to load with the `plane_name` argument. "
-                    "To see what planes are available, call `Suite2pSegmentationExtractor.get_available_planes(folder_path=...)`.",
+                    f"More than one plane is detected: {plane_names}. Using '{plane_names[0]}'. "
+                    "Please specify which plane you wish to load with the `plane_name` argument.",
                     UserWarning,
                 )
             plane_name = plane_names[0]

--- a/tests/test_suite2psegmentationextractor.py
+++ b/tests/test_suite2psegmentationextractor.py
@@ -57,12 +57,12 @@ class TestSuite2pSegmentationExtractor(TestCase):
         )
 
     def test_multi_channel_warns(self):
-        exc_msg = "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument. To see what channels are available, call `Suite2pSegmentationExtractor.get_available_channels(folder_path=...)`."
+        exc_msg = f"More than one channel is detected: {self.channel_names}. Using '{self.channel_names[0]}'. Please specify which channel you wish to load with the `channel_name` argument."
         with self.assertWarnsWith(warn_type=UserWarning, exc_msg=exc_msg):
             Suite2pSegmentationExtractor(folder_path=self.folder_path)
 
     def test_multi_plane_warns(self):
-        exc_msg = "More than one plane is detected! Please specify which plane you wish to load with the `plane_name` argument. To see what planes are available, call `Suite2pSegmentationExtractor.get_available_planes(folder_path=...)`."
+        exc_msg = f"More than one plane is detected: {self.plane_names}. Using '{self.plane_names[0]}'. Please specify which plane you wish to load with the `plane_name` argument."
         with self.assertWarnsWith(warn_type=UserWarning, exc_msg=exc_msg):
             Suite2pSegmentationExtractor(folder_path=self.folder_path, channel_name="chan2")
 


### PR DESCRIPTION
This PR improves the Suite2p warnings from telling you to use a method to get the information you need to actually giving you the information.

Before:
```
More than one plane is detected! Please specify which plane you wish to load with the `plane_name` argument. To see what planes are available, call `Suite2pSegmentationExtractor.get_available_planes(folder_path=...)`.
```

Now:
```
More than one plane is detected: ['plane0', 'plane1']. Using 'plane0'. Please specify which plane you wish to load with the `plane_name` argument.
```