### PR TITLE
Detect a compressed TIFF at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations And Removals
 
 ### Improvements
+* `MultiTiffMultiPageExtractor` and the extractors built on it now raise at construction when the TIFF compression needs `imagecodecs`, with a message that names the compression and the install command, instead of failing mid-read from inside `tifffile`. [PR #609](https://github.com/catalystneuro/roiextractors/pull/609)
 
 # v0.9.0 (June 30th, 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ ignore-words-list = 'assertin,tye,thet'
 test = [
     "pytest",
     "pytest-cov",
+    # Decoding an LZW compressed TIFF needs imagecodecs, which tifffile does not install by default.
+    # Kept out of the `full` extra so users are not made to carry it; see MultiTIFFMultiPageExtractor.
+    "tifffile[codecs]",
     "parameterized==0.8.1",
     "spikeinterface>=0.100.7",
     "pytest-xdist",

--- a/src/roiextractors/extractors/tiffimagingextractors/multitiffmultipageextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/multitiffmultipageextractor.py
@@ -199,7 +199,18 @@ class MultiTIFFMultiPageExtractor(ImagingExtractor):
         first_ifd = first_tiff.pages[0]
         self._num_rows, self._num_columns = first_ifd.shape
         self._dtype = first_ifd.dtype
+        compression = first_ifd.compression
         first_tiff.close()
+
+        # Fail here instead of on the first read, where the error arrives from deep inside tifffile
+        if compression not in self._tifffile.TIFF.DECOMPRESSORS:
+            raise ValueError(
+                f"This TIFF is {compression.name} compressed and decoding it requires the 'imagecodecs' package, "
+                f"which tifffile does not install by default. The file is not corrupt, this is a missing optional "
+                f"dependency. Install it with:\n\n"
+                f'    pip install "tifffile[codecs]"\n\n'
+                f"File: {first_path}"
+            )
 
         ifds_per_file = self._get_ifds_per_file()
         if len(ifds_per_file) != len(self._file_paths):

--- a/tests/test_multitiffmultipageextractor.py
+++ b/tests/test_multitiffmultipageextractor.py
@@ -1,5 +1,7 @@
 """Tests for the MultiTIFFMultiPageExtractor organized by test cases."""
 
+import re
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -764,3 +766,31 @@ def test_frame_to_ifd_table_on_long_planar_t_series():
     assert table.shape == (num_timepoints,)
     assert table["file_index"].max() == num_timepoints - 1
     assert table["time_index"].max() == num_timepoints - 1
+
+
+def test_missing_codec_raises_at_construction(tmp_path, monkeypatch):
+    """A TIFF whose compression tifffile cannot decode fails at construction, not mid-read."""
+    import tifffile
+
+    file_path = tmp_path / "lzw_compressed.tif"
+    with tifffile.TiffWriter(file_path) as writer:
+        writer.write(np.zeros((3, 4), dtype=np.uint16), compression="LZW")
+
+    # To test that in an environment where imagecodecs is not available the read fails,
+    # we monkeypatch tifffile.TIFF.DECOMPRESSORS to hold only the entry for uncompressed data
+    no_compression = tifffile.COMPRESSION.NONE
+    no_compression_decoder = tifffile.TIFF.DECOMPRESSORS[no_compression]
+    decompressors = {no_compression: no_compression_decoder}
+    monkeypatch.setattr(tifffile.TIFF, "DECOMPRESSORS", decompressors)
+    # After this, tifffile has no decompressor for LZW and loading the compressed
+    # TIFF fails with the expected error
+
+    expected_message = (
+        "This TIFF is LZW compressed and decoding it requires the 'imagecodecs' package, "
+        "which tifffile does not install by default. The file is not corrupt, this is a missing optional "
+        "dependency. Install it with:\n\n"
+        '    pip install "tifffile[codecs]"\n\n'
+        f"File: {file_path}"
+    )
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
+        MultiTIFFMultiPageExtractor(file_paths=[file_path], sampling_frequency=30.0)

--- a/tests/test_thortiffimagingextractor.py
+++ b/tests/test_thortiffimagingextractor.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import numpy as np
 import pytest
 import tifffile
 from numpy.testing import assert_array_equal
@@ -90,3 +91,55 @@ class TestThorTiffImagingExtractor:
         """Test that the acquisition start time is parsed from Experiment.xml."""
         expected = datetime(2023, 10, 18, 17, 39, 19, tzinfo=timezone.utc)
         assert self.extractor._get_session_start_time() == expected
+
+
+VOLUMETRIC_DIR = OPHYS_DATA_PATH / "imaging_datasets" / "ThorlabsTiff" / "multi_channel_multi_plane" / "lzw_compressed"
+
+
+class TestThorTiffImagingExtractorVolumetric:
+    """Test ThorTiffImagingExtractor on a two-channel, three-plane acquisition."""
+
+    num_samples = 3
+    num_planes = 3
+    image_shape = (128, 128)
+
+    @classmethod
+    def setup_class(cls):
+        """Set up the test."""
+        cls.file_path = VOLUMETRIC_DIR / "ChanA_0001_0001_0001_0001.tif"
+        if not cls.file_path.exists():
+            pytest.skip(f"Test file {cls.file_path} not found. Skipping tests.")
+
+        cls.extractor = ThorTiffImagingExtractor(file_path=cls.file_path, channel_name="ChanA")
+
+    def test_volumetric_shape(self):
+        """The depth planes are reported as a fourth dimension."""
+        assert self.extractor.is_volumetric
+        assert self.extractor.get_num_planes() == self.num_planes
+        assert self.extractor.get_num_samples() == self.num_samples
+        assert self.extractor.get_sample_shape() == (*self.image_shape, self.num_planes)
+
+        series = self.extractor.get_series()
+        assert series.shape == (self.num_samples, *self.image_shape, self.num_planes)
+
+    def test_sample_and_plane_are_not_transposed(self):
+        """Each (sample, plane) position holds the file named for that plane and timepoint.
+
+        ThorImage names the files ``ChanA_0001_0001_<plane>_<timepoint>.tif``, so the mapping is
+        checked against the files themselves. Shapes alone would pass even if the two were swapped.
+
+        The pages are read one at a time because ``tifffile.imread`` on the first file of the
+        acquisition returns the whole assembled OME series, not that file's single page.
+        """
+        series = self.extractor.get_series()
+        for sample_index in range(self.num_samples):
+            for plane_index in range(self.num_planes):
+                file_path = VOLUMETRIC_DIR / f"ChanA_0001_0001_000{plane_index + 1}_000{sample_index + 1}.tif"
+                with tifffile.TiffFile(file_path) as tiff_file:
+                    expected = tiff_file.pages[0].asarray()
+                assert_array_equal(series[sample_index, :, :, plane_index], expected)
+
+    def test_channels_hold_different_data(self):
+        """Selecting the other channel reads other pages."""
+        other = ThorTiffImagingExtractor(file_path=self.file_path, channel_name="ChanB")
+        assert not np.array_equal(self.extractor.get_series(), other.get_series())


### PR DESCRIPTION
While working on the past neuroconv release I was reading a ThorImageLS dataset and I hit `ValueError: <COMPRESSION.LZW: 5> requires the 'imagecodecs' package` from six frames inside `tifffile` in the middle of a read. The problem is that a compressed TIFF needs an extra on `tifffile` to read (the `imagecodecs` library).

This PR does a couple of things:
* It adds an error at construction telling users that their file is compressed with a codec this environment cannot decode, and that they need to `pip install "tifffile[codecs]"`.
* It adds an example (volumetric multi channel data for Thor, which was missing!) that tests this and adds the dependency to the test group in `pyproject.toml` so the CI can read it.
* It adds a test for the error.

Packaging design point:
The package is on the large side (`imagecodecs` is about 50 MB installed) and given that compression is mostly avoided at acquisition time I don't think it makes sense to add as a plain dependency of the library. On the other hand, users sometimes apply compression to their files and we should have a clear error and instructions on how to solve it. We could make it an extra if this becomes more complicated but, I think at this point, this is simple enough that it is not warranted.