### PR TITLE
Remove `check_get_frames_args` and `SegmentationExtractor.get_num_channels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * `ThorTiffImagingExtractor.get_available_channel_names` now reads the `Wavelengths` block of `Experiment.xml` instead of falling back to the numeric names of the OME-XML, so the names it returns are the ones the constructor accepts. [PR #610](https://github.com/catalystneuro/roiextractors/pull/610)
 
 ### Deprecations And Removals
+* Removed `check_get_frames_args()` from `extraction_tools`, deprecated for removal on or after June 2026. It decorated a `get_frames` method that no longer exists and had no callers anywhere.
+* Removed `SegmentationExtractor.get_num_channels()` and its slice passthrough, deprecated for removal on or after September 2026.
 * Removed `MultiSegmentationExtractor`. It could not be instantiated, since `SegmentationExtractor.get_native_timestamps` is abstract and the class never implemented it, so nothing that touched it had ever run. It flattened several per-plane segmentations into one list of ROI ids with a `(plane_index, roi_id)` lookup, which is none of the three aggregations that are actually wanted (appending ROI populations over the same field of view, stacking 2D masks into 3D, or concatenating traces over time). Resolves [#588](https://github.com/catalystneuro/roiextractors/issues/588)
 * Deprecated `generate_dummy_video()` (will be removed in or after March 2027). Use `GaussianNoiseImagingExtractor` or `PoissonNoiseImagingExtractor` instead. [PR #562](https://github.com/catalystneuro/roiextractors/pull/562)
 * Deprecated `has_native_timestamps` parameter in `generate_dummy_imaging_extractor()` (will be removed in or after March 2027). Use `native_timestamps="evenly_spaced"` instead. [PR #562](https://github.com/catalystneuro/roiextractors/pull/562)

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -9,7 +9,6 @@ VideoStructure
 import importlib.util
 import sys
 from dataclasses import dataclass
-from functools import wraps
 from pathlib import Path
 from platform import python_version
 from types import ModuleType
@@ -364,59 +363,6 @@ def _image_mask_extractor(pixel_mask, _roi_ids, image_shape) -> np.ndarray:
         for y, x, wt in pixel_mask[rois]:
             image_mask[int(y), int(x), no] = wt
     return image_mask
-
-
-def check_get_frames_args(func):
-    """Check the arguments of the get_frames function.
-
-    This decorator allows the get_frames function to be queried with either
-    an integer, slice or an array and handles a common return. [I think that np.take can be used instead of this]
-
-    Parameters
-    ----------
-    func: function
-        The get_frames function.
-
-    Returns
-    -------
-    corrected_args: function
-        The get_frames function with corrected arguments.
-
-    Raises
-    ------
-    AssertionError
-        If 'frame_idxs' exceed the number of frames.
-
-    Deprecated
-    ----------
-    This function will be removed on or after June 2026.
-    The get_frames method it decorates has been removed.
-    """
-    import warnings
-
-    warnings.warn(
-        "check_get_frames_args() is deprecated and will be removed on or after June 2026. "
-        "The get_frames method has been removed.",
-        FutureWarning,
-        stacklevel=2,
-    )
-
-    @wraps(func)
-    def corrected_args(imaging, frame_idxs, channel=0):
-        channel = int(channel)
-        if isinstance(frame_idxs, (int, np.integer)):
-            frame_idxs = [frame_idxs]
-        if not isinstance(frame_idxs, slice):
-            frame_idxs = np.array(frame_idxs)
-            assert np.all(frame_idxs < imaging.get_num_samples()), "'frame_idxs' exceed number of frames"
-        get_frames_correct_arg = func(imaging, frame_idxs, channel)
-
-        if not isinstance(frame_idxs, slice) and len(frame_idxs) == 1:
-            return get_frames_correct_arg[0]
-        else:
-            return get_frames_correct_arg
-
-    return corrected_args
 
 
 def _cast_start_end_frame(start_frame, end_frame):

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -687,25 +687,6 @@ class SegmentationExtractor(ABC):
 
         return 0
 
-    def get_num_channels(self) -> int:
-        """Get number of channels in the pipeline.
-
-        Returns
-        -------
-        num_of_channels: int
-            number of channels
-
-        Deprecated
-        ----------
-        This method will be removed on or after September 2026.
-        """
-        warnings.warn(
-            "get_num_channels is deprecated and will be removed on or after September 2026.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return len(self._channel_names)
-
     def get_num_planes(self) -> int:
         """Get the default number of planes of imaging for the segmentation extractor.
 
@@ -1033,9 +1014,6 @@ class SampleSlicedSegmentationExtractor(SegmentationExtractor):
 
     def get_sampling_frequency(self) -> float:
         return self._parent_segmentation.get_sampling_frequency()
-
-    def get_num_channels(self) -> int:
-        return self._parent_segmentation.get_num_channels()
 
     def get_num_planes(self) -> int:
         return self._parent_segmentation.get_num_planes()

--- a/tests/test_internals/test_frame_slice_segmentation.py
+++ b/tests/test_internals/test_frame_slice_segmentation.py
@@ -49,9 +49,6 @@ class BaseTestSampleSliceSegmentation(TestCase):
     def test_get_sampling_frequency(self):
         assert self.sample_sliced_segmentation.get_sampling_frequency() == 30.0
 
-    def test_get_num_channels(self):
-        assert self.sample_sliced_segmentation.get_num_channels() == 1
-
     def test_get_num_rois(self):
         assert self.sample_sliced_segmentation.get_num_rois() == 10
 


### PR DESCRIPTION
Both of these are past their removal dates, `check_get_frames_args` on or after June 2026 and `SegmentationExtractor.get_num_channels` on or after September 2026. This PR removes them: the first decorated a `get_frames` method that no longer exists and had no caller anywhere, and the second had only its own slice passthrough and one test.