### PR TITLE
Remove the zarr 2 pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * The `Suite2pSegmentationExtractor` warnings for multiple channels or planes now list the available names and the one being loaded instead of pointing at `get_available_channels` / `get_available_planes`. [PR #607](https://github.com/catalystneuro/roiextractors/pull/607)
 * `MultiTiffMultiPageExtractor` and the extractors built on it now raise at construction when the TIFF compression needs `imagecodecs`, with a message that names the compression and the install command, instead of failing mid-read from inside `tifffile`. [PR #609](https://github.com/catalystneuro/roiextractors/pull/609)
 * Replaced the `lazy_ops` dependency with `lazyslice`, its maintained successor from the same authors, with the same `DatasetView` and `lazy_transpose` API and support for zarr 3. [PR #615](https://github.com/catalystneuro/roiextractors/pull/615)
+* Removed the `zarr<3` and `numcodecs<0.16.0` pins, which silently downgraded zarr to 2.18.7 when `roiextractors` was installed next to zarr 3. Resolves [#384](https://github.com/catalystneuro/roiextractors/issues/384)
 
 # v0.9.0 (June 30th, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * The `Suite2pSegmentationExtractor` warnings for multiple channels or planes now list the available names and the one being loaded instead of pointing at `get_available_channels` / `get_available_planes`. [PR #607](https://github.com/catalystneuro/roiextractors/pull/607)
 * `MultiTiffMultiPageExtractor` and the extractors built on it now raise at construction when the TIFF compression needs `imagecodecs`, with a message that names the compression and the install command, instead of failing mid-read from inside `tifffile`. [PR #609](https://github.com/catalystneuro/roiextractors/pull/609)
 * Replaced the `lazy_ops` dependency with `lazyslice`, its maintained successor from the same authors, with the same `DatasetView` and `lazy_transpose` API and support for zarr 3. [PR #615](https://github.com/catalystneuro/roiextractors/pull/615)
-* Removed the `zarr<3` and `numcodecs<0.16.0` pins, which silently downgraded zarr to 2.18.7 when `roiextractors` was installed next to zarr 3. Resolves [#384](https://github.com/catalystneuro/roiextractors/issues/384)
+* Removed the `zarr<3` and `numcodecs<0.16.0` pins, which silently downgraded zarr to 2.18.7 when `roiextractors` was installed next to zarr 3, and dropped `numcodecs` as a direct dependency since nothing here imports it. Resolves [#384](https://github.com/catalystneuro/roiextractors/issues/384)
 
 # v0.9.0 (June 30th, 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "lxml",
   "packaging",
   "zarr>=2",
-  "numcodecs",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ dependencies = [
   "PyYAML",
   "lxml",
   "packaging",
-  "zarr>=2,<3",
-  "numcodecs<0.16.0",
+  "zarr>=2",
+  "numcodecs",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is the last step for zarr version 3 support, after #614 and #615.

The pins date from #383 in January 2025. While they are there, installing `roiextractors` into an environment that has zarr 3 silently downgrades zarr to 2.18.7 instead of reporting a conflict, which breaks hdmf-zarr's v3 backend with nothing pointing back here. Nothing needs them any more, so they come off.

This should close #384.
